### PR TITLE
[Feat] 가사 분석 CRUD 기능 생성

### DIFF
--- a/src/main/java/com/fifo/compasstep/apipayload/exceptions/handler/LyricsAnalysisHandler.java
+++ b/src/main/java/com/fifo/compasstep/apipayload/exceptions/handler/LyricsAnalysisHandler.java
@@ -1,0 +1,10 @@
+package com.fifo.compasstep.apipayload.exceptions.handler;
+
+import com.fifo.compasstep.apipayload.code.BaseErrorCode;
+import com.fifo.compasstep.apipayload.exceptions.GeneralException;
+
+public class LyricsAnalysisHandler extends GeneralException {
+    public LyricsAnalysisHandler(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/fifo/compasstep/lyrics_analysis/controller/LyricsAnalysisController.java
+++ b/src/main/java/com/fifo/compasstep/lyrics_analysis/controller/LyricsAnalysisController.java
@@ -5,6 +5,7 @@ import com.fifo.compasstep.apipayload.ApiResponse;
 import com.fifo.compasstep.lyrics_analysis.dto.response.LyricsAnalysisDetailResponseDTO;
 import com.fifo.compasstep.lyrics_analysis.dto.response.LyricsAnalysisListResponseDTO;
 import com.fifo.compasstep.lyrics_analysis.service.LyricsAnalysisService;
+import com.fifo.compasstep.security.userDetails.UserUserDetails;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -19,20 +20,10 @@ public class LyricsAnalysisController {
     /** 저장된 가사 분석 목록 조회 */
     @GetMapping("/lyrics-analyses")
     public ApiResponse<LyricsAnalysisListResponseDTO> getAnalyses(
-            @AuthenticationPrincipal Object principal, // 인증 개발 후 변경
-            // @RequestHeader는 인증 개발 완료 후 삭제
-            @RequestHeader(value = "X-DEV-USER-ID", required = false) String devUserId
+            @AuthenticationPrincipal UserUserDetails currentUser
     ) {
-        // 문자열 기준 Fallback 아래 내용은 인증 개발 후 삭제
-        String userIdFromAuth = extractUsername(principal); // ← 인증 붙으면 이 라인만 사용
-        String effectiveUserId =
-                (userIdFromAuth != null && !userIdFromAuth.isBlank()) ? userIdFromAuth :
-                        (devUserId != null && !devUserId.isBlank()) ? devUserId :
-                                "dev-user-123"; // 임시 기본값
-
-        // Long userIdForQuery = Long.parseLong(userIdFromAuth); // 인증 개발 후 변경하여 적용
-        Long userIdForQuery = toNumericUserIdOrDefault(effectiveUserId, 1L); // 인증 개발 후 삭제
-        var result = lyricsAnalysisService.getList(userIdForQuery);
+        Long userId = currentUser.getUser().getId();
+        var result = lyricsAnalysisService.getList(userId);
         return new ApiResponse<>(200, "저장된 가사 분석 목록 조회가 성공했습니다.", result);
     }
 
@@ -40,20 +31,10 @@ public class LyricsAnalysisController {
     @GetMapping("/lyrics-analyses/{analysisId}")
     public ApiResponse<LyricsAnalysisDetailResponseDTO> getAnalysisDetail(
             @PathVariable Long analysisId,
-            @AuthenticationPrincipal Object principal,
-            // @RequestHeader는 인증 개발 완료 후 삭제
-            @RequestHeader(value = "X-DEV-USER-ID", required = false) String devUserId
+            @AuthenticationPrincipal UserUserDetails currentUser
     ) {
-        // 아래 내용은 인증 개발 후 삭제
-        String userIdFromAuth = extractUsername(principal);
-        String effectiveUserId =
-                (userIdFromAuth != null && !userIdFromAuth.isBlank()) ? userIdFromAuth :
-                        (devUserId != null && !devUserId.isBlank()) ? devUserId :
-                                "dev-user-123"; // 임시 기본값
-
-        // Long userIdForQuery = Long.parseLong(userIdFromAuth); // // 인증 개발 후 변경하여 적용
-        Long userIdForQuery = toNumericUserIdOrDefault(effectiveUserId, 1L); // 인증 개발 후 삭제
-        var result = lyricsAnalysisService.getDetail(analysisId, userIdForQuery);
+        Long userId = currentUser.getUser().getId();
+        var result = lyricsAnalysisService.getDetail(analysisId, userId);
         return new ApiResponse<>(200, "저장된 가사 분석 상세 조회가 성공했습니다.", result);
     }
 
@@ -61,54 +42,10 @@ public class LyricsAnalysisController {
     @DeleteMapping("/lyrics-analyses/{analysisId}")
     public ApiResponse<Void> deleteAnalysis(
             @PathVariable Long analysisId,
-            @AuthenticationPrincipal Object principal,
-            // @RequestHeader는 인증 개발 완료 후 삭제
-            @RequestHeader(value = "X-DEV-USER-ID", required = false) String devUserId
+            @AuthenticationPrincipal UserUserDetails currentUser
     ) {
-        // 아래 내용은 인증 개발 후 삭제
-        String userIdFromAuth = extractUsername(principal);
-        String effectiveUserId =
-                (userIdFromAuth != null && !userIdFromAuth.isBlank()) ? userIdFromAuth :
-                        (devUserId != null && !devUserId.isBlank()) ? devUserId :
-                                "dev-user-123"; // 임시 기본값
-
-        // Long userIdForQuery = Long.parseLong(userIdFromAuth); // 인증 개발 후 변경하여 적용
-        Long userIdForQuery = toNumericUserIdOrDefault(effectiveUserId, 1L);// 인증 개발 후 변경하여 적용
-        lyricsAnalysisService.delete(analysisId, userIdForQuery);
+        Long userId = currentUser.getUser().getId();
+        lyricsAnalysisService.delete(analysisId, userId);
         return new ApiResponse<>(200, "성공했습니다.", null);
-    }
-
-
-    // 아래 내용 부터는 인증 개발 되면 삭제
-    // 인증 붙기 전까지 다양한 Principal 타입을 안전하게 username으로 추출
-    // 인증 개발 후에는 컨트롤러 파라미터를 @AuthenticationPrincipal Long userId 형태로 바꿔 이 메서드 삭제
-    private String extractUsername(Object principal) {
-        if (principal == null) return null;
-        // Spring Security 기본 UserDetails
-        if (principal instanceof org.springframework.security.core.userdetails.UserDetails u) {
-            return u.getUsername();
-        }
-        // 문자열 Principal (예: "anonymousUser")
-        if (principal instanceof String s) {
-            return !"anonymousUser".equalsIgnoreCase(s) ? s : null;
-        }
-        // 커스텀 Principal (getUsername() 메서드가 있을 경우)
-        try {
-            var m = principal.getClass().getMethod("getUsername");
-            Object v = m.invoke(principal);
-            return (v instanceof String str && !str.isBlank()) ? str : null;
-        } catch (Exception ignore) {
-            return null;
-        }
-    }
-
-    // 아래도 인증 개발 후 삭제
-    private Long toNumericUserIdOrDefault(String effectiveUserId, Long defaultValue) {
-        if (effectiveUserId == null || effectiveUserId.isBlank()) return defaultValue;
-        try {
-            return Long.parseLong(effectiveUserId.trim());
-        } catch (NumberFormatException ignored) {
-            return defaultValue; // ex) "dev-user-123" → 1L 로 대체
-        }
     }
 }

--- a/src/main/java/com/fifo/compasstep/lyrics_analysis/controller/LyricsAnalysisController.java
+++ b/src/main/java/com/fifo/compasstep/lyrics_analysis/controller/LyricsAnalysisController.java
@@ -24,7 +24,7 @@ public class LyricsAnalysisController {
     ) {
         Long userId = currentUser.getUser().getId();
         var result = lyricsAnalysisService.getList(userId);
-        return new ApiResponse<>(200, "저장된 가사 분석 목록 조회가 성공했습니다.", result);
+        return ApiResponse.success(result);
     }
 
     /** 저장된 가사 분석 상세 조회 */
@@ -35,7 +35,7 @@ public class LyricsAnalysisController {
     ) {
         Long userId = currentUser.getUser().getId();
         var result = lyricsAnalysisService.getDetail(analysisId, userId);
-        return new ApiResponse<>(200, "저장된 가사 분석 상세 조회가 성공했습니다.", result);
+        return ApiResponse.success(result);
     }
 
     /** 저장된 가사 분석 삭제 */
@@ -46,6 +46,6 @@ public class LyricsAnalysisController {
     ) {
         Long userId = currentUser.getUser().getId();
         lyricsAnalysisService.delete(analysisId, userId);
-        return new ApiResponse<>(200, "성공했습니다.", null);
+        return ApiResponse.success(null);
     }
 }

--- a/src/main/java/com/fifo/compasstep/lyrics_analysis/controller/LyricsAnalysisController.java
+++ b/src/main/java/com/fifo/compasstep/lyrics_analysis/controller/LyricsAnalysisController.java
@@ -1,0 +1,114 @@
+// src/main/java/com/fifo/compasstep/lyrics_analysis/controller/LyricsAnalysisController.java
+package com.fifo.compasstep.lyrics_analysis.controller;
+
+import com.fifo.compasstep.apipayload.ApiResponse;
+import com.fifo.compasstep.lyrics_analysis.dto.response.LyricsAnalysisDetailResponseDTO;
+import com.fifo.compasstep.lyrics_analysis.dto.response.LyricsAnalysisListResponseDTO;
+import com.fifo.compasstep.lyrics_analysis.service.LyricsAnalysisService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/user/mypage")
+public class LyricsAnalysisController {
+
+    private final LyricsAnalysisService lyricsAnalysisService;
+
+    /** 저장된 가사 분석 목록 조회 */
+    @GetMapping("/lyrics-analyses")
+    public ApiResponse<LyricsAnalysisListResponseDTO> getAnalyses(
+            @AuthenticationPrincipal Object principal, // 인증 개발 후 변경
+            // @RequestHeader는 인증 개발 완료 후 삭제
+            @RequestHeader(value = "X-DEV-USER-ID", required = false) String devUserId
+    ) {
+        // 문자열 기준 Fallback 아래 내용은 인증 개발 후 삭제
+        String userIdFromAuth = extractUsername(principal); // ← 인증 붙으면 이 라인만 사용
+        String effectiveUserId =
+                (userIdFromAuth != null && !userIdFromAuth.isBlank()) ? userIdFromAuth :
+                        (devUserId != null && !devUserId.isBlank()) ? devUserId :
+                                "dev-user-123"; // 임시 기본값
+
+        // Long userIdForQuery = Long.parseLong(userIdFromAuth); // 인증 개발 후 변경하여 적용
+        Long userIdForQuery = toNumericUserIdOrDefault(effectiveUserId, 1L); // 인증 개발 후 삭제
+        var result = lyricsAnalysisService.getList(userIdForQuery);
+        return new ApiResponse<>(200, "저장된 가사 분석 목록 조회가 성공했습니다.", result);
+    }
+
+    /** 저장된 가사 분석 상세 조회 */
+    @GetMapping("/lyrics-analyses/{analysisId}")
+    public ApiResponse<LyricsAnalysisDetailResponseDTO> getAnalysisDetail(
+            @PathVariable Long analysisId,
+            @AuthenticationPrincipal Object principal,
+            // @RequestHeader는 인증 개발 완료 후 삭제
+            @RequestHeader(value = "X-DEV-USER-ID", required = false) String devUserId
+    ) {
+        // 아래 내용은 인증 개발 후 삭제
+        String userIdFromAuth = extractUsername(principal);
+        String effectiveUserId =
+                (userIdFromAuth != null && !userIdFromAuth.isBlank()) ? userIdFromAuth :
+                        (devUserId != null && !devUserId.isBlank()) ? devUserId :
+                                "dev-user-123"; // 임시 기본값
+
+        // Long userIdForQuery = Long.parseLong(userIdFromAuth); // // 인증 개발 후 변경하여 적용
+        Long userIdForQuery = toNumericUserIdOrDefault(effectiveUserId, 1L); // 인증 개발 후 삭제
+        var result = lyricsAnalysisService.getDetail(analysisId, userIdForQuery);
+        return new ApiResponse<>(200, "저장된 가사 분석 상세 조회가 성공했습니다.", result);
+    }
+
+    /** 저장된 가사 분석 삭제 */
+    @DeleteMapping("/lyrics-analyses/{analysisId}")
+    public ApiResponse<Void> deleteAnalysis(
+            @PathVariable Long analysisId,
+            @AuthenticationPrincipal Object principal,
+            // @RequestHeader는 인증 개발 완료 후 삭제
+            @RequestHeader(value = "X-DEV-USER-ID", required = false) String devUserId
+    ) {
+        // 아래 내용은 인증 개발 후 삭제
+        String userIdFromAuth = extractUsername(principal);
+        String effectiveUserId =
+                (userIdFromAuth != null && !userIdFromAuth.isBlank()) ? userIdFromAuth :
+                        (devUserId != null && !devUserId.isBlank()) ? devUserId :
+                                "dev-user-123"; // 임시 기본값
+
+        // Long userIdForQuery = Long.parseLong(userIdFromAuth); // 인증 개발 후 변경하여 적용
+        Long userIdForQuery = toNumericUserIdOrDefault(effectiveUserId, 1L);// 인증 개발 후 변경하여 적용
+        lyricsAnalysisService.delete(analysisId, userIdForQuery);
+        return new ApiResponse<>(200, "성공했습니다.", null);
+    }
+
+
+    // 아래 내용 부터는 인증 개발 되면 삭제
+    // 인증 붙기 전까지 다양한 Principal 타입을 안전하게 username으로 추출
+    // 인증 개발 후에는 컨트롤러 파라미터를 @AuthenticationPrincipal Long userId 형태로 바꿔 이 메서드 삭제
+    private String extractUsername(Object principal) {
+        if (principal == null) return null;
+        // Spring Security 기본 UserDetails
+        if (principal instanceof org.springframework.security.core.userdetails.UserDetails u) {
+            return u.getUsername();
+        }
+        // 문자열 Principal (예: "anonymousUser")
+        if (principal instanceof String s) {
+            return !"anonymousUser".equalsIgnoreCase(s) ? s : null;
+        }
+        // 커스텀 Principal (getUsername() 메서드가 있을 경우)
+        try {
+            var m = principal.getClass().getMethod("getUsername");
+            Object v = m.invoke(principal);
+            return (v instanceof String str && !str.isBlank()) ? str : null;
+        } catch (Exception ignore) {
+            return null;
+        }
+    }
+
+    // 아래도 인증 개발 후 삭제
+    private Long toNumericUserIdOrDefault(String effectiveUserId, Long defaultValue) {
+        if (effectiveUserId == null || effectiveUserId.isBlank()) return defaultValue;
+        try {
+            return Long.parseLong(effectiveUserId.trim());
+        } catch (NumberFormatException ignored) {
+            return defaultValue; // ex) "dev-user-123" → 1L 로 대체
+        }
+    }
+}

--- a/src/main/java/com/fifo/compasstep/lyrics_analysis/domain/LyricsAnalysisRepository.java
+++ b/src/main/java/com/fifo/compasstep/lyrics_analysis/domain/LyricsAnalysisRepository.java
@@ -1,0 +1,63 @@
+package com.fifo.compasstep.lyrics_analysis.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+public interface LyricsAnalysisRepository extends JpaRepository<LyricsAnalysis, Long> {
+
+    /*  목록 조회 (userId 기준) */
+    interface ListRow {
+        Long getLyricsAnalysisId();
+        String getLyricsTitle();
+        Instant getCreatedAt();
+    }
+
+    @Query(value = """
+            SELECT
+                la.id AS lyricsAnalysisId,
+                l.title AS lyricsTitle,
+                la.created_at AS createdAt
+            FROM lyrics_analysis la
+            JOIN lyrics l ON la.lyrics_id = l.id
+            WHERE l.user_id = :userId
+            ORDER BY la.created_at DESC
+            """, nativeQuery = true)
+    List<ListRow> findListByUserId(@Param("userId") Long userId);
+
+    /*  상세 조회 (analysisId 기준) */
+    interface DetailRow {
+        Long getLyricsAnalysisId();
+        String getLyricsTitle();
+        Instant getCreatedAt();
+        String getAnalysisResult(); // jsonb 문자열
+    }
+
+    @Query(value = """
+            SELECT
+                la.id AS lyricsAnalysisId,
+                l.title AS lyricsTitle,
+                la.created_at AS createdAt,
+                cast(la.analysis_result as text) AS analysisResult
+            FROM lyrics_analysis la
+            JOIN lyrics l ON la.lyrics_id = l.id
+            WHERE la.id = :analysisId
+            """, nativeQuery = true)
+    Optional<DetailRow> findDetailById(@Param("analysisId") Long analysisId);
+
+    /*  권한/소유자 확인 */
+    @Query(value = """
+    SELECT NOT EXISTS (
+      SELECT 1
+      FROM lyrics_analysis la
+      JOIN lyrics l ON la.lyrics_id = l.id
+      WHERE la.id = :analysisId AND l.user_id = :userId
+    )
+    """, nativeQuery = true)
+    boolean notExistsByIdAndUserId(@Param("analysisId") Long analysisId, @Param("userId") Long userId);
+
+}

--- a/src/main/java/com/fifo/compasstep/lyrics_analysis/domain/LyricsAnalysisRepository.java
+++ b/src/main/java/com/fifo/compasstep/lyrics_analysis/domain/LyricsAnalysisRepository.java
@@ -1,63 +1,28 @@
 package com.fifo.compasstep.lyrics_analysis.domain;
 
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
-
-import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
 public interface LyricsAnalysisRepository extends JpaRepository<LyricsAnalysis, Long> {
 
-    /*  목록 조회 (userId 기준) */
-    interface ListRow {
-        Long getLyricsAnalysisId();
-        String getLyricsTitle();
-        Instant getCreatedAt();
+    // 목록: 특정 사용자(userId) 기준 최신순
+    Page<LyricsAnalysis> findByLyrics_UserIdOrderByCreatedAtDesc(Long userId, Pageable pageable);
+
+    // 목록: 페이징 없이 전부 (필요 시)
+    List<LyricsAnalysis> findByLyrics_UserIdOrderByCreatedAtDesc(Long userId);
+
+    // 상세: 기본 제공 findById(Long) 써도 되지만, 명시적으로 두고 싶으면 아래 유지
+    // Optional<LyricsAnalysis> findById(Long id);
+
+    // 권한/소유자 확인
+    boolean existsByIdAndLyrics_UserId(Long id, Long userId);
+
+    // notExists 형태가 필요하면 기본 메서드로 제공
+    default boolean notExistsByIdAndUserId(Long analysisId, Long userId) {
+        return !existsByIdAndLyrics_UserId(analysisId, userId);
     }
-
-    @Query(value = """
-            SELECT
-                la.id AS lyricsAnalysisId,
-                l.title AS lyricsTitle,
-                la.created_at AS createdAt
-            FROM lyrics_analysis la
-            JOIN lyrics l ON la.lyrics_id = l.id
-            WHERE l.user_id = :userId
-            ORDER BY la.created_at DESC
-            """, nativeQuery = true)
-    List<ListRow> findListByUserId(@Param("userId") Long userId);
-
-    /*  상세 조회 (analysisId 기준) */
-    interface DetailRow {
-        Long getLyricsAnalysisId();
-        String getLyricsTitle();
-        Instant getCreatedAt();
-        String getAnalysisResult(); // jsonb 문자열
-    }
-
-    @Query(value = """
-            SELECT
-                la.id AS lyricsAnalysisId,
-                l.title AS lyricsTitle,
-                la.created_at AS createdAt,
-                cast(la.analysis_result as text) AS analysisResult
-            FROM lyrics_analysis la
-            JOIN lyrics l ON la.lyrics_id = l.id
-            WHERE la.id = :analysisId
-            """, nativeQuery = true)
-    Optional<DetailRow> findDetailById(@Param("analysisId") Long analysisId);
-
-    /*  권한/소유자 확인 */
-    @Query(value = """
-    SELECT NOT EXISTS (
-      SELECT 1
-      FROM lyrics_analysis la
-      JOIN lyrics l ON la.lyrics_id = l.id
-      WHERE la.id = :analysisId AND l.user_id = :userId
-    )
-    """, nativeQuery = true)
-    boolean notExistsByIdAndUserId(@Param("analysisId") Long analysisId, @Param("userId") Long userId);
-
 }

--- a/src/main/java/com/fifo/compasstep/lyrics_analysis/dto/response/AnalysisDataItemDTO.java
+++ b/src/main/java/com/fifo/compasstep/lyrics_analysis/dto/response/AnalysisDataItemDTO.java
@@ -1,0 +1,13 @@
+// src/main/java/com/fifo/compasstep/lyrics_analysis/dto/response/AnalysisDataItemDto.java
+package com.fifo.compasstep.lyrics_analysis.dto.response;
+
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record AnalysisDataItemDTO(
+        String part,
+        List<String> emotions,
+        String coaching
+) {}

--- a/src/main/java/com/fifo/compasstep/lyrics_analysis/dto/response/AnalysisResultDTO.java
+++ b/src/main/java/com/fifo/compasstep/lyrics_analysis/dto/response/AnalysisResultDTO.java
@@ -1,0 +1,10 @@
+package com.fifo.compasstep.lyrics_analysis.dto.response;
+
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record AnalysisResultDTO(
+        List<AnalysisDataItemDTO> analysisData
+) {}

--- a/src/main/java/com/fifo/compasstep/lyrics_analysis/dto/response/LyricsAnalysisDetailResponseDTO.java
+++ b/src/main/java/com/fifo/compasstep/lyrics_analysis/dto/response/LyricsAnalysisDetailResponseDTO.java
@@ -1,0 +1,13 @@
+package com.fifo.compasstep.lyrics_analysis.dto.response;
+
+import lombok.Builder;
+
+import java.time.Instant;
+
+@Builder
+public record LyricsAnalysisDetailResponseDTO(
+        Long lyricsAnalysisId,
+        String lyricsTitle,
+        Instant createdAt,
+        AnalysisResultDTO analysisResult
+) {}

--- a/src/main/java/com/fifo/compasstep/lyrics_analysis/dto/response/LyricsAnalysisListItemDTO.java
+++ b/src/main/java/com/fifo/compasstep/lyrics_analysis/dto/response/LyricsAnalysisListItemDTO.java
@@ -1,0 +1,12 @@
+package com.fifo.compasstep.lyrics_analysis.dto.response;
+
+import lombok.Builder;
+
+import java.time.Instant;
+
+@Builder
+public record LyricsAnalysisListItemDTO(
+        Long lyricsAnalysisId,
+        String lyricsTitle,
+        Instant createdAt
+) {}

--- a/src/main/java/com/fifo/compasstep/lyrics_analysis/dto/response/LyricsAnalysisListResponseDTO.java
+++ b/src/main/java/com/fifo/compasstep/lyrics_analysis/dto/response/LyricsAnalysisListResponseDTO.java
@@ -1,0 +1,10 @@
+package com.fifo.compasstep.lyrics_analysis.dto.response;
+
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record LyricsAnalysisListResponseDTO(
+        List<LyricsAnalysisListItemDTO> analyses
+) {}

--- a/src/main/java/com/fifo/compasstep/lyrics_analysis/exceptions/LyricsAnalysisErrorStatus.java
+++ b/src/main/java/com/fifo/compasstep/lyrics_analysis/exceptions/LyricsAnalysisErrorStatus.java
@@ -1,0 +1,47 @@
+// src/main/java/com/fifo/compasstep/lyrics_analysis/exceptions/LyricsAnalysisErrorStatus.java
+package com.fifo.compasstep.lyrics_analysis.exceptions;
+
+import com.fifo.compasstep.apipayload.code.BaseErrorCode;
+import com.fifo.compasstep.apipayload.code.ErrorReasonDTO;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum LyricsAnalysisErrorStatus implements BaseErrorCode {
+
+    // 400
+    INVALID_REQUEST(HttpStatus.BAD_REQUEST, 400, "잘못된 요청입니다."),
+
+    // 403 (선택: 소유자/권한 검증 시 사용)
+    FORBIDDEN_ACCESS(HttpStatus.FORBIDDEN, 403, "해당 리소스에 대한 권한이 없습니다."),
+
+    // 404
+    ANALYSIS_NOT_FOUND(HttpStatus.NOT_FOUND, 404, "가사 분석을 찾을 수 없습니다."),
+
+    // 500
+    JSON_PARSE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 500, "분석 결과를 파싱하는 중 오류가 발생했습니다."),
+    DB_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 500, "데이터 처리 중 오류가 발생했습니다.");
+
+    private final HttpStatus status;
+    private final int code;
+    private final String message;
+
+    @Override
+    public ErrorReasonDTO getReason() {
+        return ErrorReasonDTO.builder()
+                .message(message)
+                .code(code)
+                .build();
+    }
+
+    @Override
+    public ErrorReasonDTO getReasonHttpStatus() {
+        return ErrorReasonDTO.builder()
+                .message(message)
+                .code(code)
+                .httpStatus(status)
+                .build();
+    }
+}

--- a/src/main/java/com/fifo/compasstep/lyrics_analysis/service/LyricsAnalysisService.java
+++ b/src/main/java/com/fifo/compasstep/lyrics_analysis/service/LyricsAnalysisService.java
@@ -2,17 +2,21 @@
 package com.fifo.compasstep.lyrics_analysis.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fifo.compasstep.apipayload.exceptions.GeneralException;
+import com.fifo.compasstep.apipayload.exceptions.handler.LyricsAnalysisHandler;
+import com.fifo.compasstep.lyrics_analysis.domain.LyricsAnalysis;
 import com.fifo.compasstep.lyrics_analysis.domain.LyricsAnalysisRepository;
+import com.fifo.compasstep.lyrics_analysis.dto.response.AnalysisResultDTO;
 import com.fifo.compasstep.lyrics_analysis.dto.response.LyricsAnalysisDetailResponseDTO;
 import com.fifo.compasstep.lyrics_analysis.dto.response.LyricsAnalysisListItemDTO;
 import com.fifo.compasstep.lyrics_analysis.dto.response.LyricsAnalysisListResponseDTO;
-import com.fifo.compasstep.lyrics_analysis.dto.response.AnalysisResultDTO;
 import com.fifo.compasstep.lyrics_analysis.exceptions.LyricsAnalysisErrorStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.List;
 
 @Service
@@ -25,12 +29,12 @@ public class LyricsAnalysisService {
 
     /** 가사 분석 목록 조회 (userId 기준) */
     public LyricsAnalysisListResponseDTO getList(Long userId) {
-        var rows = repo.findListByUserId(userId);
+        List<LyricsAnalysis> rows = repo.findByLyrics_UserIdOrderByCreatedAtDesc(userId);
         List<LyricsAnalysisListItemDTO> items = rows.stream()
-                .map(r -> LyricsAnalysisListItemDTO.builder()
-                        .lyricsAnalysisId(r.getLyricsAnalysisId())
-                        .lyricsTitle(r.getLyricsTitle())
-                        .createdAt(r.getCreatedAt())
+                .map(e -> LyricsAnalysisListItemDTO.builder()
+                        .lyricsAnalysisId(e.getId())
+                        .lyricsTitle(e.getLyrics().getTitle())
+                        .createdAt(toInstant(e.getCreatedAt()))
                         .build()
                 ).toList();
 
@@ -41,20 +45,20 @@ public class LyricsAnalysisService {
 
     /** 가사 분석 상세 조회 (analysisId + userId) */
     public LyricsAnalysisDetailResponseDTO getDetail(Long analysisId, Long userId) {
-        // 소유자 확인 (임시 인증 단계에서도 보안용으로 유지 권장)
-        if (repo.notExistsByIdAndUserId(analysisId, userId)) {
-            throw new GeneralException(LyricsAnalysisErrorStatus.FORBIDDEN_ACCESS);
+        // 권한/소유자 확인
+        if (!repo.existsByIdAndLyrics_UserId(analysisId, userId)) {
+            throw new LyricsAnalysisHandler(LyricsAnalysisErrorStatus.FORBIDDEN_ACCESS);
         }
 
-        var row = repo.findDetailById(analysisId)
-                .orElseThrow(() -> new GeneralException(LyricsAnalysisErrorStatus.ANALYSIS_NOT_FOUND));
+        LyricsAnalysis entity = repo.findById(analysisId)
+                .orElseThrow(() -> new LyricsAnalysisHandler(LyricsAnalysisErrorStatus.ANALYSIS_NOT_FOUND));
 
-        AnalysisResultDTO parsed = parseResult(row.getAnalysisResult());
+        AnalysisResultDTO parsed = parseResult(entity.getAnalysisResult());
 
         return LyricsAnalysisDetailResponseDTO.builder()
-                .lyricsAnalysisId(row.getLyricsAnalysisId())
-                .lyricsTitle(row.getLyricsTitle())
-                .createdAt(row.getCreatedAt())
+                .lyricsAnalysisId(entity.getId())
+                .lyricsTitle(entity.getLyrics().getTitle())
+                .createdAt(toInstant(entity.getCreatedAt()))
                 .analysisResult(parsed)
                 .build();
     }
@@ -62,12 +66,11 @@ public class LyricsAnalysisService {
     /** 저장된 가사 분석 삭제 (analysisId + userId) */
     @Transactional
     public void delete(Long analysisId, Long userId) {
-        if (repo.notExistsByIdAndUserId(analysisId, userId)) {
-            throw new GeneralException(LyricsAnalysisErrorStatus.FORBIDDEN_ACCESS);
+        if (!repo.existsByIdAndLyrics_UserId(analysisId, userId)) {
+            throw new LyricsAnalysisHandler(LyricsAnalysisErrorStatus.FORBIDDEN_ACCESS);
         }
-        // 존재 여부 한 번 더 확인 (선택)
-        var found = repo.findById(analysisId)
-                .orElseThrow(() -> new GeneralException(LyricsAnalysisErrorStatus.ANALYSIS_NOT_FOUND));
+        LyricsAnalysis found = repo.findById(analysisId)
+                .orElseThrow(() -> new LyricsAnalysisHandler(LyricsAnalysisErrorStatus.ANALYSIS_NOT_FOUND));
         repo.delete(found);
     }
 
@@ -76,7 +79,15 @@ public class LyricsAnalysisService {
         try {
             return objectMapper.readValue(json, AnalysisResultDTO.class);
         } catch (Exception e) {
-            throw new GeneralException(LyricsAnalysisErrorStatus.JSON_PARSE_ERROR);
+            throw new LyricsAnalysisHandler(LyricsAnalysisErrorStatus.JSON_PARSE_ERROR);
         }
+    }
+
+    // LocalDateTime → Instant 변환 (KST 기준)
+    private static Instant toInstant(LocalDateTime ldt) {
+        // 서버 표준 시간대를 KST(UTC+9)로 고정하여 변환
+        return ldt.atOffset(ZoneOffset.ofHours(9)).toInstant();
+        // 필요시 시스템 타임존 사용:
+        // return ldt.atZone(ZoneId.systemDefault()).toInstant();
     }
 }

--- a/src/main/java/com/fifo/compasstep/lyrics_analysis/service/LyricsAnalysisService.java
+++ b/src/main/java/com/fifo/compasstep/lyrics_analysis/service/LyricsAnalysisService.java
@@ -1,0 +1,82 @@
+// src/main/java/com/fifo/compasstep/lyrics_analysis/service/LyricsAnalysisService.java
+package com.fifo.compasstep.lyrics_analysis.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fifo.compasstep.apipayload.exceptions.GeneralException;
+import com.fifo.compasstep.lyrics_analysis.domain.LyricsAnalysisRepository;
+import com.fifo.compasstep.lyrics_analysis.dto.response.LyricsAnalysisDetailResponseDTO;
+import com.fifo.compasstep.lyrics_analysis.dto.response.LyricsAnalysisListItemDTO;
+import com.fifo.compasstep.lyrics_analysis.dto.response.LyricsAnalysisListResponseDTO;
+import com.fifo.compasstep.lyrics_analysis.dto.response.AnalysisResultDTO;
+import com.fifo.compasstep.lyrics_analysis.exceptions.LyricsAnalysisErrorStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class LyricsAnalysisService {
+
+    private final LyricsAnalysisRepository repo;
+    private final ObjectMapper objectMapper;
+
+    /** 가사 분석 목록 조회 (userId 기준) */
+    public LyricsAnalysisListResponseDTO getList(Long userId) {
+        var rows = repo.findListByUserId(userId);
+        List<LyricsAnalysisListItemDTO> items = rows.stream()
+                .map(r -> LyricsAnalysisListItemDTO.builder()
+                        .lyricsAnalysisId(r.getLyricsAnalysisId())
+                        .lyricsTitle(r.getLyricsTitle())
+                        .createdAt(r.getCreatedAt())
+                        .build()
+                ).toList();
+
+        return LyricsAnalysisListResponseDTO.builder()
+                .analyses(items)
+                .build();
+    }
+
+    /** 가사 분석 상세 조회 (analysisId + userId) */
+    public LyricsAnalysisDetailResponseDTO getDetail(Long analysisId, Long userId) {
+        // 소유자 확인 (임시 인증 단계에서도 보안용으로 유지 권장)
+        if (repo.notExistsByIdAndUserId(analysisId, userId)) {
+            throw new GeneralException(LyricsAnalysisErrorStatus.FORBIDDEN_ACCESS);
+        }
+
+        var row = repo.findDetailById(analysisId)
+                .orElseThrow(() -> new GeneralException(LyricsAnalysisErrorStatus.ANALYSIS_NOT_FOUND));
+
+        AnalysisResultDTO parsed = parseResult(row.getAnalysisResult());
+
+        return LyricsAnalysisDetailResponseDTO.builder()
+                .lyricsAnalysisId(row.getLyricsAnalysisId())
+                .lyricsTitle(row.getLyricsTitle())
+                .createdAt(row.getCreatedAt())
+                .analysisResult(parsed)
+                .build();
+    }
+
+    /** 저장된 가사 분석 삭제 (analysisId + userId) */
+    @Transactional
+    public void delete(Long analysisId, Long userId) {
+        if (repo.notExistsByIdAndUserId(analysisId, userId)) {
+            throw new GeneralException(LyricsAnalysisErrorStatus.FORBIDDEN_ACCESS);
+        }
+        // 존재 여부 한 번 더 확인 (선택)
+        var found = repo.findById(analysisId)
+                .orElseThrow(() -> new GeneralException(LyricsAnalysisErrorStatus.ANALYSIS_NOT_FOUND));
+        repo.delete(found);
+    }
+
+    /* 내부 유틸 */
+    private AnalysisResultDTO parseResult(String json) {
+        try {
+            return objectMapper.readValue(json, AnalysisResultDTO.class);
+        } catch (Exception e) {
+            throw new GeneralException(LyricsAnalysisErrorStatus.JSON_PARSE_ERROR);
+        }
+    }
+}

--- a/src/main/java/com/fifo/compasstep/reference/controller/ReferenceController.java
+++ b/src/main/java/com/fifo/compasstep/reference/controller/ReferenceController.java
@@ -2,10 +2,10 @@
 package com.fifo.compasstep.reference.controller;
 
 import com.fifo.compasstep.apipayload.ApiResponse;
-import com.fifo.compasstep.reference.dto.RankingItemDto;
-import com.fifo.compasstep.reference.dto.ReferenceRequestDto;
-import com.fifo.compasstep.reference.dto.YoutubeLinkRequestDto;
-import com.fifo.compasstep.reference.dto.YoutubeLinkResponseDto;
+import com.fifo.compasstep.reference.dto.RankingItemDTO;
+import com.fifo.compasstep.reference.dto.ReferenceRequestDTO;
+import com.fifo.compasstep.reference.dto.YoutubeLinkRequestDTO;
+import com.fifo.compasstep.reference.dto.YoutubeLinkResponseDTO;
 import com.fifo.compasstep.reference.service.GenreRankingService;
 import com.fifo.compasstep.reference.service.YoutubeLinkService;
 import jakarta.validation.constraints.Max;
@@ -27,24 +27,24 @@ public class ReferenceController {
     private final YoutubeLinkService youtubeLinkService;
 
     @GetMapping("/rankings")
-    public ApiResponse<List<RankingItemDto>> getRankings(
+    public ApiResponse<List<RankingItemDTO>> getRankings(
             @RequestParam @NotBlank(message = "장르를 지정해주세요.") String genre,
             @RequestParam(required = false) String market,
             @RequestParam(required = false) @Min(1) @Max(50) Integer limit
     ) {
-        List<RankingItemDto> list = genreRankingService.getGenreRanking(
-                new ReferenceRequestDto(genre, market, limit)
+        List<RankingItemDTO> list = genreRankingService.getGenreRanking(
+                new ReferenceRequestDTO(genre, market, limit)
         );
         return new ApiResponse<>(200, "장르별 랭킹 조회를 성공했습니다.", list);
     }
 
     @GetMapping("/youtube-link")
-    public ApiResponse<YoutubeLinkResponseDto> getYoutubeLink(
+    public ApiResponse<YoutubeLinkResponseDTO> getYoutubeLink(
             @RequestParam @NotBlank(message = "곡 제목을 지정해주세요.") String title,
             @RequestParam @NotBlank(message = "아티스트 이름을 지정해주세요.") String artist
     ) {
-        YoutubeLinkResponseDto res = youtubeLinkService.getYoutubeLink(
-                new YoutubeLinkRequestDto(title, artist)
+        YoutubeLinkResponseDTO res = youtubeLinkService.getYoutubeLink(
+                new YoutubeLinkRequestDTO(title, artist)
         );
         return new ApiResponse<>(200, "유튜브 링크 조회를 성공했습니다.", res);
     }

--- a/src/main/java/com/fifo/compasstep/reference/dto/RankingItemDTO.java
+++ b/src/main/java/com/fifo/compasstep/reference/dto/RankingItemDTO.java
@@ -1,7 +1,7 @@
 // src/main/java/com/fifo/compasstep/reference/dto/RankingItemDto.java
 package com.fifo.compasstep.reference.dto;
 
-public record RankingItemDto(
+public record RankingItemDTO(
         int rank,
         String songTitle,
         String artistName,

--- a/src/main/java/com/fifo/compasstep/reference/dto/ReferenceRequestDTO.java
+++ b/src/main/java/com/fifo/compasstep/reference/dto/ReferenceRequestDTO.java
@@ -5,7 +5,7 @@ import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 
-public record ReferenceRequestDto(
+public record ReferenceRequestDTO(
         @NotBlank String genre,
         String market,
         @Min(1) @Max(50) Integer limit

--- a/src/main/java/com/fifo/compasstep/reference/dto/YoutubeLinkRequestDTO.java
+++ b/src/main/java/com/fifo/compasstep/reference/dto/YoutubeLinkRequestDTO.java
@@ -3,7 +3,7 @@ package com.fifo.compasstep.reference.dto;
 
 import jakarta.validation.constraints.NotBlank;
 
-public record YoutubeLinkRequestDto(
+public record YoutubeLinkRequestDTO(
         @NotBlank String title,
         @NotBlank String artist   // optional
 ) {}

--- a/src/main/java/com/fifo/compasstep/reference/dto/YoutubeLinkResponseDTO.java
+++ b/src/main/java/com/fifo/compasstep/reference/dto/YoutubeLinkResponseDTO.java
@@ -1,7 +1,7 @@
 // src/main/java/com/fifo/compasstep/reference/dto/YoutubeLinkResponseDto.java
 package com.fifo.compasstep.reference.dto;
 
-public record YoutubeLinkResponseDto(
+public record YoutubeLinkResponseDTO(
         String title,
         String artist,
         String url

--- a/src/main/java/com/fifo/compasstep/reference/service/GenreRankingService.java
+++ b/src/main/java/com/fifo/compasstep/reference/service/GenreRankingService.java
@@ -3,8 +3,8 @@ package com.fifo.compasstep.reference.service;
 
 import com.fifo.compasstep.apipayload.exceptions.GeneralException;
 import com.fifo.compasstep.reference.client.SpotifyClient;
-import com.fifo.compasstep.reference.dto.RankingItemDto;
-import com.fifo.compasstep.reference.dto.ReferenceRequestDto;
+import com.fifo.compasstep.reference.dto.RankingItemDTO;
+import com.fifo.compasstep.reference.dto.ReferenceRequestDTO;
 import com.fifo.compasstep.reference.exceptions.ReferenceErrorStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -18,7 +18,7 @@ public class GenreRankingService {
     private final SpotifyClient spotifyClient;
 
     /** Spotify 장르 기반 인기 트랙 */
-    public List<RankingItemDto> getGenreRanking(ReferenceRequestDto req) {
+    public List<RankingItemDTO> getGenreRanking(ReferenceRequestDTO req) {
         try {
             String token = spotifyClient.getAccessToken();
 
@@ -36,7 +36,7 @@ public class GenreRankingService {
                     .limit(req.limitOrDefault())
                     .toList();
 
-            List<RankingItemDto> result = new ArrayList<>();
+            List<RankingItemDTO> result = new ArrayList<>();
             int rank = 1;
             for (Map<String, Object> t : sorted) {
                 result.add(toRankingItem(rank++, t));
@@ -58,11 +58,11 @@ public class GenreRankingService {
         return (List<Map<String, Object>>) tracks.getOrDefault("items", List.of());
     }
 
-    private RankingItemDto toRankingItem(int rank, Map<String, Object> t) {
+    private RankingItemDTO toRankingItem(int rank, Map<String, Object> t) {
         String title = Objects.toString(t.get("name"), "");
         String artistName = extractFirstArtistName(t);
         String imageUrl = extractAlbumImageUrl(t); // ★ Spotify album.images 사용
-        return new RankingItemDto(rank, title, artistName, imageUrl);
+        return new RankingItemDTO(rank, title, artistName, imageUrl);
     }
 
     @SuppressWarnings("unchecked")

--- a/src/main/java/com/fifo/compasstep/reference/service/YoutubeLinkService.java
+++ b/src/main/java/com/fifo/compasstep/reference/service/YoutubeLinkService.java
@@ -3,8 +3,8 @@ package com.fifo.compasstep.reference.service;
 
 import com.fifo.compasstep.apipayload.exceptions.GeneralException;
 import com.fifo.compasstep.reference.client.YoutubeClient;
-import com.fifo.compasstep.reference.dto.YoutubeLinkRequestDto;
-import com.fifo.compasstep.reference.dto.YoutubeLinkResponseDto;
+import com.fifo.compasstep.reference.dto.YoutubeLinkRequestDTO;
+import com.fifo.compasstep.reference.dto.YoutubeLinkResponseDTO;
 import com.fifo.compasstep.reference.exceptions.ReferenceErrorStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -16,10 +16,10 @@ public class YoutubeLinkService {
     private final YoutubeClient youtubeClient;
 
     /** 특정 곡의 유튜브 상위 링크 반환(없으면 url=null) */
-    public YoutubeLinkResponseDto getYoutubeLink(YoutubeLinkRequestDto req) {
+    public YoutubeLinkResponseDTO getYoutubeLink(YoutubeLinkRequestDTO req) {
         try {
             String url = youtubeClient.findTopVideoUrl(req.title(), req.artist());
-            return new YoutubeLinkResponseDto(req.title(), req.artist(), url);
+            return new YoutubeLinkResponseDTO(req.title(), req.artist(), url);
         } catch (Exception e) {
             throw new GeneralException(ReferenceErrorStatus.EXTERNAL_API_ERROR);
         }

--- a/src/main/java/com/fifo/compasstep/user/profile/controller/UserProfileController.java
+++ b/src/main/java/com/fifo/compasstep/user/profile/controller/UserProfileController.java
@@ -25,7 +25,7 @@ public class UserProfileController {
     ) {
         Long userId = currentUser.getUser().getId();
         var result = service.getProfileInfo(userId);
-        return new ApiResponse<>(200, "사용자 프로필 정보 조회를 성공했습니다.", result);
+        return ApiResponse.success(result);
     }
 
     @PatchMapping("/image")
@@ -35,7 +35,7 @@ public class UserProfileController {
     ) {
         Long userId = currentUser.getUser().getId();
         service.updateProfileImage(userId, req.getFileKey());
-        return new ApiResponse<>(200, "프로필 이미지가 성공적으로 변경되었습니다.", null);
+        return ApiResponse.success(null);
     }
 
     @PatchMapping("/nickname")
@@ -45,6 +45,6 @@ public class UserProfileController {
     ) {
         Long userId = currentUser.getUser().getId();
         service.updateNickname(userId, req.getNickname());
-        return new ApiResponse<>(200, "닉네임이 성공적으로 변경되었습니다.", null);
+        return ApiResponse.success(null);
     }
 }


### PR DESCRIPTION
## 🔗 관련 이슈
해당 PR이 연결되는 이슈 번호를 명시하세요.  
Issue #3 

---

## ✨ 변경 내용
이번 PR에서 어떤 작업을 했는지 요약해주세요.
- 가사 분석 목록 조회 기능 생성
- 가사 분석 상세 조회 기능 생성
- 특정 가사 분석 삭제 기능 생성
- 파일 명칭 Dto -> DTO로 수정

---

## 🧪 테스트 방법
어떻게 동작을 검증했는지 작성해주세요.
- [ ] Swagger를 통해 가사 분석 목록 조회 기능 테스트, 해당 유저 것인지 확인
- [ ] Swagger를 통해 가사 분석 상세 조회 기능 테스트, 해당 유저 것인지 확인
- [ ] Swagger를 통해 특정 가사 분석 삭제 기능 테스트, 해당 유저 것인지 확인
- [ ] 삭제 기능 수행 시 실제로 가사 분석 테이블의 값이 삭제되는지 확인

---

## 👀 리뷰 포인트
리뷰어가 집중해서 봐줬으면 하는 부분을 적어주세요.
- 장르 별 레퍼런스 탐색 기능에서 수정된 부분은 Dto라고 되어있던 파일명을 DTO라고 통일하는 과정에서 import 줄이 바뀌었거나 파일 명자체가 달라진 부분이니 해당 부분은 리뷰 생략하셔도 됩니다.
- 아직 인증 부분은 구현되지 않아 임시로 controller를 저렇게 구현하였습니다. 인증 부분이 구현된 이후 수정할 예정입니다.

---

## 📎 기타 참고 사항
리뷰에 도움이 될만한 추가 맥락, 스크린샷, 관련 문서 링크 등을 남겨주세요.
### Swagger를 통해 가사 분석 목록 조회 기능 테스트, 해당 유저 것인지 확인
- Swagger 사진
<img width="1170" height="858" alt="image" src="https://github.com/user-attachments/assets/27fc0197-6a85-464d-9ac4-7f34f0221ea4" />

### Swagger를 통해 가사 분석 상세 조회 기능 테스트, 해당 유저 것인지 확인
- Swagger 사진
<img width="1177" height="815" alt="image" src="https://github.com/user-attachments/assets/7ccdaf6a-63f0-4ecc-b413-a7bb90c6a97c" />

### Swagger를 통해 특정 가사 분석 삭제 기능 테스트, 해당 유저 것인지 확인
- Swagger 사진
<img width="609" height="501" alt="image" src="https://github.com/user-attachments/assets/63001d31-65ed-4acd-bdd5-608edd003baf" />

### 삭제 기능 수행 시 실제로 가사 분석 테이블의 값이 삭제되는지 확인
- 삭제 전 테이블 사진
<img width="757" height="307" alt="image" src="https://github.com/user-attachments/assets/a80d6897-2cea-40c9-a373-8ef99cf67634" />

- 삭제 후 테이블 사진
<img width="741" height="269" alt="image" src="https://github.com/user-attachments/assets/22bddaf7-d38c-4bb5-a3b5-58d7130694f4" />

