### PR TITLE
[Feat] admin 나머지 로직 구현

### DIFF
--- a/src/main/java/com/fifo/compasstep/admin/controller/AdminController.java
+++ b/src/main/java/com/fifo/compasstep/admin/controller/AdminController.java
@@ -53,4 +53,39 @@ public class AdminController {
         return ApiResponse.success(null);
     }
 
+    // 임시 비밀번호를 실제 비밀번호로 변경
+    @PatchMapping("/password/change")
+    @PreAuthorize("hasRole('GENERAL')")
+    public ApiResponse<Void> changePassword(
+            @Valid @RequestBody AdminRequestDTO.ChangePasswordRequestDTO request) {
+        adminService.changePassword(request);
+        return ApiResponse.success(null);
+    }
+
+    // 관리자 초대는 루트만 가능
+    @PostMapping("/password/invite")
+    @PreAuthorize("hasRole('ROOT')")
+    public ApiResponse<Void> inviteAdmin(
+            @RequestBody AdminRequestDTO.InviteRequestDTO request){
+        adminService.invite(request);
+        return ApiResponse.success(null);
+    }
+
+    //루트관리자가 타 관리자 비밀번호 재발급
+    @PatchMapping("/password/reissue")
+    @PreAuthorize("hasRole('ROOT')")
+    public ApiResponse<Void> reissueAdmin(
+            @Valid @RequestBody AdminRequestDTO.ReissueRequestDTO request){
+        adminService.reissue(request);
+        return ApiResponse.success(null);
+    }
+
+    // 관리자 전체 목록 조회
+    @GetMapping("/admins")
+    @PreAuthorize("hasRole('ROOT')")
+    public ApiResponse<AdminResponseDTO.AdminListResponseDTO> getAllAdmins() {
+        AdminResponseDTO.AdminListResponseDTO result = adminService.getAllAdmins();
+        return ApiResponse.success(result);
+    }
+
 }

--- a/src/main/java/com/fifo/compasstep/admin/dto/AdminRequestDTO.java
+++ b/src/main/java/com/fifo/compasstep/admin/dto/AdminRequestDTO.java
@@ -30,6 +30,8 @@ public class AdminRequestDTO {
 
     @Getter
     @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
     public static class ReissueRequestDTO {
         private String adminPKId;
     }

--- a/src/main/java/com/fifo/compasstep/admin/dto/AdminResponseDTO.java
+++ b/src/main/java/com/fifo/compasstep/admin/dto/AdminResponseDTO.java
@@ -1,7 +1,11 @@
 package com.fifo.compasstep.admin.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
 
 public class AdminResponseDTO {
     @Getter
@@ -9,6 +13,23 @@ public class AdminResponseDTO {
     public static class LoginResponseDTO {
         //private String accessToken;
         private String csrfToken;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class AdminListResponseDTO {
+        private List<AdminInfoDTO> adminList;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class AdminInfoDTO {
+        private String nickname;
+        private String email;
     }
 
 }

--- a/src/main/java/com/fifo/compasstep/admin/repository/AdminRepository.java
+++ b/src/main/java/com/fifo/compasstep/admin/repository/AdminRepository.java
@@ -1,13 +1,15 @@
 package com.fifo.compasstep.admin.repository;
 
 import com.fifo.compasstep.admin.domain.Admin;
+import com.fifo.compasstep.admin.enums.Role;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface AdminRepository extends JpaRepository<Admin, Integer> {
     Optional<Admin> findByEmail(String email);
     Optional<Admin> findById(Long AdminId);
     Boolean existsByEmail(String email);
-
+    List<Admin> findByRole(Role role);
 }

--- a/src/main/java/com/fifo/compasstep/admin/service/AdminService.java
+++ b/src/main/java/com/fifo/compasstep/admin/service/AdminService.java
@@ -6,6 +6,7 @@ import com.fifo.compasstep.admin.dto.AdminRequestDTO;
 import com.fifo.compasstep.admin.dto.AdminResponseDTO;
 import com.fifo.compasstep.admin.exceptions.AdminErrorStatus;
 import com.fifo.compasstep.admin.repository.AdminRepository;
+import com.fifo.compasstep.apipayload.ApiResponse;
 import com.fifo.compasstep.apipayload.exceptions.handler.AdminHandler;
 import com.fifo.compasstep.security.jwt.JwtProperties;
 import com.fifo.compasstep.security.jwt.JwtTokenProvider;
@@ -22,6 +23,7 @@ import lombok.extern.slf4j.Slf4j; // Slf4j import
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails; // UserDetails import
 import org.springframework.security.core.userdetails.UsernameNotFoundException; // Exception import
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -29,11 +31,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.UUID;
+import java.util.*;
+import java.util.stream.Collectors;
 
 @Slf4j // 로그 사용을 위해 추가
 @Service
@@ -203,6 +202,98 @@ public class AdminService {
 
         refreshTokenService.removeRefreshTokenByUser(adminToDelete.getId(), "ADMIN");
     }
+
+    // changePassword 메소드는 현재 로그인한 관리자의 비밀번호를 변경하는 로직
+    // UserDetails에서 현재 관리자 ID를 가져와서 처리해야 합니다
+    @Transactional
+    public void changePassword(AdminRequestDTO.ChangePasswordRequestDTO request) {
+        // 패스워드 더블체크
+        if (!request.getPassword().equals(request.getDoubleCheck())) {
+            throw new AdminHandler(AdminErrorStatus.PASSWORD_NOT_MATCH);
+        }
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !(authentication.getPrincipal() instanceof AdminUserDetails)) {
+            // 인증 정보가 없거나, 예상치 못한 Principal 타입인 경우 예외 처리
+            throw new AdminHandler(AdminErrorStatus.ADMIN_NOT_FOUND); // 적절한 에러 상태 정의 필요
+        }
+        AdminUserDetails currentUserDetails = (AdminUserDetails) authentication.getPrincipal();
+        Long currentAdminId = currentUserDetails.getAdmin().getId();
+
+        Admin admin = adminRepository.findById(currentAdminId)
+                .orElseThrow(() -> new AdminHandler(AdminErrorStatus.ADMIN_NOT_FOUND));
+
+        admin.changePassword(passwordEncoder.encode(request.getPassword())); // 엔티티에 비밀번호 변경 메소드 추가 가정
+        // adminRepository.save(admin); // @Transactional이므로 자동 변경 감지 (Dirty Checking)
+    }
+
+    @Transactional
+    public void invite(AdminRequestDTO.InviteRequestDTO request) {
+        // 이미 가입된 이메일인지 확인
+        if (adminRepository.existsByEmail(request.getEmail())) {
+            throw new AdminHandler(AdminErrorStatus.EMAIL_ALREADY_EXISTS);
+        }
+
+        Map<String, String> tempPasswordInfo = makeTemPassword();
+        String tempPassword = tempPasswordInfo.get("temp");
+        String encodedPassword = tempPasswordInfo.get("encoded");
+
+        // Admin 객체 생성 및 저장
+        Admin newAdmin = Admin.builder()
+                .email(request.getEmail())
+                .password(encodedPassword)
+                .name("초대된 관리자") // 임시 이름 또는 DTO에서 받기
+                .role(Role.GENERAL) // 기본 역할은 GENERAL로 가정
+                .tempPwd(true) // 임시 비밀번호 상태
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .build();
+        adminRepository.save(newAdmin);
+
+        // 이메일 발송
+        emailService.sendInvitationEmail(request.getEmail(), tempPassword, "newuser");
+    }
+
+    @Transactional
+    public void reissue(AdminRequestDTO.ReissueRequestDTO request) {
+        Long adminPKId = Long.valueOf(request.getAdminPKId());
+        Admin passwordChangeAdmin = adminRepository.findById(adminPKId)
+                .orElseThrow(() -> new AdminHandler(AdminErrorStatus.ADMIN_NOT_FOUND));
+
+        Map<String, String> tempPasswordInfo = makeTemPassword();
+        String tempPassword = tempPasswordInfo.get("temp");
+        String encodedPassword = tempPasswordInfo.get("encoded");
+
+        // 이메일 발송
+        emailService.sendInvitationEmail(passwordChangeAdmin.getEmail(), tempPassword, "changepassword");
+
+        // 비밀번호 업데이트 및 임시 비밀번호 상태 변경
+        passwordChangeAdmin.changePassword(encodedPassword); // 엔티티에 비밀번호 변경 메소드 추가 가정
+        passwordChangeAdmin.setTempPwd(true); // 임시 비밀번호 상태로 변경
+        // adminRepository.save(passwordChangeAdmin); // @Transactional
+    }
+
+    @Transactional
+    public AdminResponseDTO.AdminListResponseDTO getAllAdmins() {
+        // 1. DB에서 삭제되지 않은 모든 Admin 조회
+        //List<Admin> adminEntities = adminRepository.findAllByIsDeletedFalse(); // isDeleted가 false인 것만 조회 (Repository에 메소드 추가 필요)
+        List<Admin> adminEntities = adminRepository.findByRole(Role.GENERAL);
+
+        // 또는 List<Admin> adminEntities = adminRepository.findAll(); // 우선 모든 관리자 조회
+
+        // 2. Admin 엔티티 리스트를 AdminInfoDTO 리스트로 변환 (Java Stream API 사용)
+        List<AdminResponseDTO.AdminInfoDTO> adminInfoDTOs = adminEntities.stream()
+                .map(admin -> AdminResponseDTO.AdminInfoDTO.builder()
+                        .nickname(admin.getName()) // 엔티티의 name 필드를 nickname으로 매핑
+                        .email(admin.getEmail())
+                        .build())
+                .collect(Collectors.toList());
+
+        // 3. 최종 DTO로 감싸서 반환
+        return AdminResponseDTO.AdminListResponseDTO.builder()
+                .adminList(adminInfoDTOs)
+                .build();
+    }
+
     private Map<String, String> makeTemPassword() {
         Map<String, String> tempPassword = new HashMap<>();
         String temp = UUID.randomUUID().toString().substring(0, 8);

--- a/src/main/java/com/fifo/compasstep/admin/service/EmailService.java
+++ b/src/main/java/com/fifo/compasstep/admin/service/EmailService.java
@@ -1,5 +1,6 @@
 package com.fifo.compasstep.admin.service;
 
+import com.fifo.compasstep.apipayload.exceptions.handler.UserHandler;
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
 import lombok.RequiredArgsConstructor;
@@ -18,143 +19,85 @@ public class EmailService {
     @Value("${app.invitation.base-url}")
     private String invitationBaseUrl;
 
-    public void sendInvitationEmail(String email, String temppassword) {
-        String subject = "Flow 관리자 초대";
+    public void sendInvitationEmail(String email, String temppassword, String condition) {
+        String subject = "compasstep 관리자 초대";
         String signupLink = invitationBaseUrl;
+        String htmlTemplate;
+        if(condition.equals("newuser")){
+            htmlTemplate = """
+                    <div style="font-family: Arial, sans-serif; color: #333; max-width: 600px; margin: auto; border: 1px solid #eee; padding: 20px;">
+                            <p style="font-size: 14px; color: #555;">
+                              <strong>From:</strong> Compassstep Admin &lt;no-reply@compasstep.com&gt;<br>
+                              <strong>To:</strong> inviteEmail
+                            </p>
+                            <p>
+                              <span style="background-color: #e0f2fe; color: #0c4a6e; padding: 5px 10px; border-radius: 15px; font-size: 12px; font-weight: bold; margin-right: 5px;">#관리자 초대</span>
+                              <span style="background-color: #e0f2fe; color: #0c4a6e; padding: 5px 10px; border-radius: 15px; font-size: 12px; font-weight: bold;">#임시 PW</span>
+                            </p>
+                            <h2 style="font-size: 24px; color: #111;">안녕하세요,</h2>
+                            <p style="font-size: 16px; line-height: 1.6;">
+                              Compassstep 관리자 콘솔에 초대되었습니다.<br>
+                              아래 임시 비밀번호로 로그인 후, 비밀번호를 변경해주세요.
+                            </p>
+                            <div style="background-color: #f3f4f6; padding: 20px; border-radius: 8px; text-align: left; margin: 24px 0;">
+                              <p style="margin: 0; font-size: 14px; color: #6b7280;">임시 비밀번호</p>
+                              <p style="margin: 10px 0 0; font-size: 24px; color: #111; font-weight: bold; letter-spacing: 2px;">newtemppassword</p>
+                            </div>
+                            <div style="text-align: center;">
+                              <a href="PLACEHOLDER_SIGNUP_LINK" target="_blank" style="display: inline-block; background-color: #111; color: #ffffff; padding: 14px 24px; border-radius: 8px; text-decoration: none; font-weight: bold; margin-top: 12px;">비밀번호 변경하기</a>
+                              <br>
+                              <a href="PLACEHOLDER_SIGNUP_LINK" target="_blank" style="display: inline-block; color: #2563eb; text-decoration: none; margin-top: 16px; font-size: 14px;">브라우저에서 열기</a>
+                            </div>
+                            <hr style="border: none; border-top: 1px solid #eee; margin: 32px 0;">
+                            <div style="background-color: #f3f4f6; padding: 15px; border-radius: 8px; text-align: left;">
+                              <p><span style="background-color: #e5e7eb; color: #4b5563; padding: 4px 8px; border-radius: 15px; font-size: 12px; font-weight: bold;">보안 알림</span></p>
+                              <p style="font-size: 12px; color: #6b7280; line-height: 1.6;">
+                                이 메일은 발신 전용입니다. 문의: support@compasstep.com
+                              </p>
+                            </div>
+                            <p style="text-align: center; font-size: 12px; color: #9ca3af; margin-top: 24px;">© 2025 Compassstep. All rights reserved.</p>
+                          </div>""";
 
-        String htmlTemplate = """
-                <!doctype html>
-                <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
-                <head>
-                  <title>Flow 관리자 초대</title>
-                  <!--[if !mso]><!-->
-                  <meta http-equiv="X-UA-Compatible" content="IE=edge">
-                  <!--<![endif]-->
-                  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-                  <meta name="viewport" content="width=device-width, initial-scale=1">
-                  <style type="text/css">
-                    #outlook a { padding: 0; }
-                    body { margin: 0; padding: 0; -webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; }
-                    table, td { border-collapse: collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; }
-                    img { border: 0; height: auto; line-height: 100%; outline: none; text-decoration: none; -ms-interpolation-mode: bicubic; }
-                    p { display: block; margin: 13px 0; }
-                  </style>
-                  <!--[if mso]>
-                  <noscript>
-                  <xml>
-                  <o:OfficeDocumentSettings>
-                    <o:AllowPNG/>
-                    <o:PixelsPerInch>96</o:PixelsPerInch>
-                  </o:OfficeDocumentSettings>
-                  </xml>
-                  </noscript>
-                  <![endif]-->
-                  <!--[if lte mso 11]>
-                  <style type="text/css">
-                    .mj-outlook-group-fix { width:100% !important; }
-                  </style>
-                  <![endif]-->
-                  <!--[if !mso]><!-->
-                  <link href="https://fonts.googleapis.com/css?family=Ubuntu:300,400,500,700" rel="stylesheet" type="text/css">
-                  <style type="text/css">
-                    @import url(https://fonts.googleapis.com/css?family=Ubuntu:300,400,500,700);
-                  </style>
-                  <!--<![endif]-->
-                  <style type="text/css">
-                    @media only screen and (min-width:480px) {
-                      .mj-column-per-100 { width: 100% !important; max-width: 100%; }
-                    }
-                  </style>
-                  <style media="screen and (min-width:480px)">
-                    .moz-text-html .mj-column-per-100 { width: 100% !important; max-width: 100%; }
-                  </style>
-                  <style type="text/css">
-                    @media only screen and (max-width:479px) {
-                      table.mj-full-width-mobile { width: 100% !important; }
-                      td.mj-full-width-mobile { width: auto !important; }
-                    }
-                  </style>
-                  <style type="text/css">
-                    @keyframes fadeInUp {
-                      from { opacity: 0; transform: translateY(30px); }
-                      to { opacity: 1; transform: translateY(0); }
-                    }
-                    @keyframes pulse {
-                      0%, 100% { transform: scale(1); opacity: 1; }
-                      50% { transform: scale(1.05); opacity: 0.8; }
-                    }
-                    .fade-in { animation: fadeInUp 1s ease-out; }
-                    .logo-pulse { animation: pulse 2s infinite; }
-                    .invite-button { transition: all 0.3s ease !important; position: relative !important; overflow: hidden !important; }
-                  </style>
-                </head>
-                <body style="word-spacing:normal;">
-                  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">관리자 등록을 완료해주세요</div>
-                  <div style="" lang="und" dir="auto">
-                    <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="fade-in-outlook" role="presentation" style="width:600px;" width="600" bgcolor="#E7ECF5" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
-                    <div class="fade-in" style="background:#E7ECF5;background-color:#E7ECF5;margin:0px auto;border-radius:8px;max-width:600px;">
-                      <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#E7ECF5;background-color:#E7ECF5;width:100%;border-radius:8px;">
-                        <tbody>
-                          <tr>
-                            <td style="direction:ltr;font-size:0px;padding:80px 20px;text-align:center;">
-                              <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:560px;" ><![endif]-->
-                              <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
-                                <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
-                                  <tbody>
-                                    <tr>
-                                      <td align="center" class="logo-pulse" style="font-size:0px;padding:10px 25px;padding-bottom:32px;word-break:break-word;">
-                                        <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:collapse;border-spacing:0px;">
-                                          <tbody>
-                                            <tr>
-                                              <td style="width:160px;">
-                                                <img alt="FLOW 아이콘" src="https://umc-perfume-bucket.s3.ap-northeast-1.amazonaws.com/FLOW_icon.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="160" height="auto" />
-                                              </td>
-                                            </tr>
-                                          </tbody>
-                                        </table>
-                                      </td>
-                                    </tr>
-                                    <tr>
-                                      <td align="center" class="fade-in" style="font-size:0px;padding:10px 25px;padding-bottom:32px;word-break:break-word;">
-                                        <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:32px;font-weight:700;line-height:1;text-align:center;color:#202124;">Flow 관리자 초대</div>
-                                      </td>
-                                    </tr>
-                                    <tr>
-                                      <td align="center" class="fade-in" style="font-size:0px;padding:10px 25px;padding-bottom:32px;word-break:break-word;">
-                                        <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:20px;line-height:1.5;text-align:center;color:#5f6368;">아래 링크를 통해 관리자 등록을 완료해주세요.<br> (링크는 12시간 동안 유효합니다)</div>
-                                      </td>
-                                    </tr>
-                                    <tr>
-                                      <td align="center" class="invite-button" style="font-size:0px;padding:16px 32px;word-break:break-word;">
-                                        <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:separate;width:280px;line-height:100%;">
-                                          <tbody>
-                                            <tr>
-                                              <td align="center" bgcolor="#0F429D" role="presentation" style="border:none;border-radius:8px;cursor:auto;mso-padding-alt:10px 25px;background:#0F429D;" valign="middle">
-                                                <a href="PLACEHOLDER_SIGNUP_LINK" style="display:inline-block;width:230px;background:#0F429D;color:white;font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px 25px;mso-padding-alt:0px;border-radius:8px;" target="_blank"> 회원가입 하러가기 </a>
-                                              </td>
-                                            </tr>
-                                          </tbody>
-                                        </table>
-                                      </td>
-                                    </tr>
-                                  </tbody>
-                                </table>
-                              </div>
-                              <!--[if mso | IE]></td></tr></table><![endif]-->
-                            </td>
-                          </tr>
-                        </tbody>
-                      </table>
-                    </div>
-                    <!--[if mso | IE]></td></tr></table><![endif]-->
-                  </div>
-                  asdf
-                </body>
-                </html>
-                """;
+        }
+        else{
+            htmlTemplate = """
+                    <div style="font-family: Arial, sans-serif; color: #333; max-width: 600px; margin: auto; border: 1px solid #eee; padding: 20px;">
+                            <p style="font-size: 14px; color: #555;">
+                              <strong>From:</strong> Compassstep Security &lt;no-reply@compasstep.com&gt;<br>
+                              <strong>To:</strong> inviteEmail
+                            </p>
+                            <p>
+                              <span style="background-color: #dcfce7; color: #166534; padding: 5px 10px; border-radius: 15px; font-size: 12px; font-weight: bold;">#비밀번호 재설정</span>
+                            </p>
+                            <h2 style="font-size: 24px; color: #111;">요청하신 계정의 임시 비밀번호를 발급했습니다.</h2>
+                            <p style="font-size: 16px; line-height: 1.6;">
+                              아래 정보를 사용해 로그인하세요.
+                            </p>
+                            <div style="background-color: #f3f4f6; padding: 20px; border-radius: 8px; text-align: left; margin: 24px 0;">
+                              <p style="margin: 0 0 16px; font-size: 14px; color: #6b7280;">이메일</p>
+                              <p style="margin: 0 0 16px; font-size: 16px; color: #111; font-weight: bold;">${adminToReset.id}</p>
+                              <hr style="border: none; border-top: 1px solid #e5e7eb;">
+                              <p style="margin: 16px 0; font-size: 14px; color: #6b7280;">임시 비밀번호</p>
+                              <p style="margin: 0; font-size: 16px; color: #111; font-weight: bold; letter-spacing: 1px;">newtemppassword</p>
+                            </div>
+                            <div style="text-align: center;">
+                              <a href="PLACEHOLDER_SIGNUP_LINK" target="_blank" style="display: inline-block; background-color: #111; color: #ffffff; padding: 14px 24px; border-radius: 8px; text-decoration: none; font-weight: bold; margin-top: 12px;">로그인 페이지</a>
+                            </div>
+                            <p style="text-align: center; font-size: 12px; color: #9ca3af; margin-top: 24px;">보안을 위해 최초 로그인 시 비밀번호 변경 절차가 진행됩니다.</p>
+                            <hr style="border: none; border-top: 1px solid #eee; margin: 32px 0;">
+                            <p style="text-align: center; font-size: 12px; color: #9ca3af;">
+                              문제가 있나요? support@compasstep.com 으로 문의해주세요.<br>
+                              © 2025 Compassstep. All rights reserved.
+                            </p>
+                          </div>""";
+        }
 
-        String htmlContent0 = htmlTemplate.replace("PLACEHOLDER_SIGNUP_LINK", "http://localhost:8080");
-        String htmlContent = htmlTemplate.replace("asdf", temppassword);
+
+
+
+        String htmlContent0 = htmlTemplate.replace("PLACEHOLDER_SIGNUP_LINK", signupLink);
+        String htmlContent1 = htmlContent0.replace("newtemppassword", temppassword);
+        String htmlContent = htmlContent1.replace("inviteEmail", email);
 
         try {
             MimeMessage mimeMessage = javaMailSender.createMimeMessage();


### PR DESCRIPTION
## 🔗 관련 이슈
Issue #27 

---

## ✨ 변경 내용
- 관리자 초대
- 관리자 비밀번호 변경(임시->실제)
- 관리자 비밀번호 재발급
- 관리자 전체 조회(루트가 일반 관리자 보기)


---

## 🧪 테스트 방법
어떻게 동작을 검증했는지 작성해주세요.
- [ ] 관리자 초대
관리자 초대 api 작성 시 db
<img width="883" height="141" alt="스크린샷 2025-10-26 124742" src="https://github.com/user-attachments/assets/42175855-0700-4ac3-9e4d-aee3e6938009" />

실제로 간 이메일
<img width="811" height="975" alt="image" src="https://github.com/user-attachments/assets/e7707153-18ab-45ac-ab46-a402dfa55b52" />

해당 이메일로 로그인 성공
<img width="2136" height="569" alt="스크린샷 2025-10-26 124055" src="https://github.com/user-attachments/assets/a7c7e390-3cc6-41c8-b6ed-e3ab0874a0b3" />

- [ ] 루트 관리자가 일반 관리자 비밀번호 변경

해당 유저의 pkid값을 넘길 경우 메일 발송
<img width="962" height="786" alt="스크린샷 2025-10-26 131301" src="https://github.com/user-attachments/assets/617d66d2-3812-4c36-8a3a-e16ed6e3c177" />

- [ ]비밀번호 변경

<img width="1081" height="150" alt="스크린샷 2025-10-26 123959" src="https://github.com/user-attachments/assets/6f654523-3dbc-4087-8fd7-02be6340e01a" />

- [ ] 관리자 조회
<img width="1165" height="762" alt="image" src="https://github.com/user-attachments/assets/7ed71711-ec79-4fee-9fb6-a797eb97e030" />

---


## 👀 리뷰 포인트


---

## 📎 기타 참고 사항

