### PR TITLE
[Feat] 유저 도메인별 기능 구현

### DIFF
--- a/src/main/java/com/fifo/compasstep/chat/repository/ChatRepository.java
+++ b/src/main/java/com/fifo/compasstep/chat/repository/ChatRepository.java
@@ -1,0 +1,11 @@
+package com.fifo.compasstep.chat.repository;
+
+import com.fifo.compasstep.chat.domain.Chat;
+import com.fifo.compasstep.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ChatRepository extends JpaRepository<Chat, Integer> {
+    List<Chat> findTop20ByUserOrderByCreatedAtDesc(User user);
+}

--- a/src/main/java/com/fifo/compasstep/chat/repository/CustomChatRepository.java
+++ b/src/main/java/com/fifo/compasstep/chat/repository/CustomChatRepository.java
@@ -1,0 +1,4 @@
+package com.fifo.compasstep.chat.repository;
+
+public interface CustomChatRepository {
+}

--- a/src/main/java/com/fifo/compasstep/chat/repository/CustomChatRepositoryImpl.java
+++ b/src/main/java/com/fifo/compasstep/chat/repository/CustomChatRepositoryImpl.java
@@ -1,0 +1,4 @@
+package com.fifo.compasstep.chat.repository;
+
+public class CustomChatRepositoryImpl {
+}

--- a/src/main/java/com/fifo/compasstep/common/dto/StoreRequestDTO.java
+++ b/src/main/java/com/fifo/compasstep/common/dto/StoreRequestDTO.java
@@ -1,0 +1,11 @@
+package com.fifo.compasstep.common.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class StoreRequestDTO {
+    String title;
+    String fileKey;
+}

--- a/src/main/java/com/fifo/compasstep/common/dto/StoreResponseDTO.java
+++ b/src/main/java/com/fifo/compasstep/common/dto/StoreResponseDTO.java
@@ -1,0 +1,11 @@
+package com.fifo.compasstep.common.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+// 가사 혹은 노래를 저장하고 반환해주는 공통 dto
+@Getter
+@Builder
+public class StoreResponseDTO {
+    private Long content_id;
+}

--- a/src/main/java/com/fifo/compasstep/lyrics/controller/LyricsController.java
+++ b/src/main/java/com/fifo/compasstep/lyrics/controller/LyricsController.java
@@ -9,8 +9,9 @@ import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
-@Controller
+@RestController
 @RequestMapping("/api/lyrics")
 @RequiredArgsConstructor
 public class LyricsController {

--- a/src/main/java/com/fifo/compasstep/lyrics/controller/LyricsController.java
+++ b/src/main/java/com/fifo/compasstep/lyrics/controller/LyricsController.java
@@ -1,0 +1,26 @@
+package com.fifo.compasstep.lyrics.controller;
+
+import com.fifo.compasstep.apipayload.ApiResponse;
+import com.fifo.compasstep.common.dto.StoreRequestDTO;
+import com.fifo.compasstep.common.dto.StoreResponseDTO;
+import com.fifo.compasstep.lyrics.service.LyricsService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+@RequestMapping("/api/lyrics")
+@RequiredArgsConstructor
+public class LyricsController {
+    private final LyricsService lyricsService;
+
+    @PostMapping("/files/store")
+    public ApiResponse<StoreResponseDTO> storeLyrics(
+            @RequestBody StoreRequestDTO request) {
+
+        StoreResponseDTO result = lyricsService.storeLyrics(request);
+        return ApiResponse.success(result);
+    }
+}

--- a/src/main/java/com/fifo/compasstep/lyrics/dto/LyricsRequestDTO.java
+++ b/src/main/java/com/fifo/compasstep/lyrics/dto/LyricsRequestDTO.java
@@ -1,0 +1,10 @@
+package com.fifo.compasstep.lyrics.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+//public class LyricsRequestDTO {
+//    @Getter
+//    @Builder
+//    public static class
+//}

--- a/src/main/java/com/fifo/compasstep/lyrics/dto/LyricsResponseDTO.java
+++ b/src/main/java/com/fifo/compasstep/lyrics/dto/LyricsResponseDTO.java
@@ -1,0 +1,10 @@
+package com.fifo.compasstep.lyrics.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+public class LyricsResponseDTO {
+//    @Getter
+//    @Builder
+//    public static class
+}

--- a/src/main/java/com/fifo/compasstep/lyrics/repository/CustomLyricsRepository.java
+++ b/src/main/java/com/fifo/compasstep/lyrics/repository/CustomLyricsRepository.java
@@ -1,0 +1,4 @@
+package com.fifo.compasstep.lyrics.repository;
+
+public interface CustomLyricsRepository {
+}

--- a/src/main/java/com/fifo/compasstep/lyrics/repository/CustomLyricsRepositoryImpl.java
+++ b/src/main/java/com/fifo/compasstep/lyrics/repository/CustomLyricsRepositoryImpl.java
@@ -1,0 +1,4 @@
+package com.fifo.compasstep.lyrics.repository;
+
+public class CustomLyricsRepositoryImpl {
+}

--- a/src/main/java/com/fifo/compasstep/lyrics/repository/LyricsRepository.java
+++ b/src/main/java/com/fifo/compasstep/lyrics/repository/LyricsRepository.java
@@ -1,0 +1,10 @@
+package com.fifo.compasstep.lyrics.repository;
+
+import com.fifo.compasstep.lyrics.domain.Lyrics;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface LyricsRepository extends JpaRepository<Lyrics, Integer> {
+    //Lyrics save(Lyrics lyrics);
+}

--- a/src/main/java/com/fifo/compasstep/lyrics/service/LyricsService.java
+++ b/src/main/java/com/fifo/compasstep/lyrics/service/LyricsService.java
@@ -1,0 +1,49 @@
+package com.fifo.compasstep.lyrics.service;
+
+import com.fifo.compasstep.admin.exceptions.AdminErrorStatus;
+import com.fifo.compasstep.apipayload.exceptions.handler.AdminHandler;
+import com.fifo.compasstep.apipayload.exceptions.handler.UserHandler;
+import com.fifo.compasstep.common.dto.StoreRequestDTO;
+import com.fifo.compasstep.common.dto.StoreResponseDTO;
+import com.fifo.compasstep.lyrics.domain.Lyrics;
+import com.fifo.compasstep.lyrics.repository.LyricsRepository;
+import com.fifo.compasstep.security.userDetails.AdminUserDetails;
+import com.fifo.compasstep.security.userDetails.UserUserDetails;
+import com.fifo.compasstep.user.exceptions.UserErrorStatus;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class LyricsService {
+    private final LyricsRepository lyricsRepository;
+
+    public StoreResponseDTO storeLyrics(StoreRequestDTO request) {
+        // 현재 로그인된 사용자 정보 가져오기
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !(authentication.getPrincipal() instanceof UserUserDetails)) {
+            // 인증 정보가 없거나, 예상치 못한 Principal 타입인 경우 예외 처리
+            throw new UserHandler(UserErrorStatus.USER_NOT_FOUND); // 적절한 에러 상태 정의 필요
+        }
+        // 현재 로그인 된 사용자 정보 / 이름 / 파일 키 가져옴
+        UserUserDetails currentUserDetails = (UserUserDetails) authentication.getPrincipal();
+        String title = request.getTitle();
+        String fileKey = request.getFileKey();
+
+
+        Lyrics lyrics = Lyrics.builder()
+                .title(title)
+                .s3Lyrics(fileKey)
+                .user(currentUserDetails.getUser())
+                .build();
+        Lyrics saved = lyricsRepository.save(lyrics);
+
+        return StoreResponseDTO.builder()
+                .content_id(saved.getId())
+                .build();
+    }
+}

--- a/src/main/java/com/fifo/compasstep/lyrics/service/LyricsService.java
+++ b/src/main/java/com/fifo/compasstep/lyrics/service/LyricsService.java
@@ -15,6 +15,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service
@@ -22,6 +23,7 @@ import org.springframework.stereotype.Service;
 public class LyricsService {
     private final LyricsRepository lyricsRepository;
 
+    @Transactional
     public StoreResponseDTO storeLyrics(StoreRequestDTO request) {
         // 현재 로그인된 사용자 정보 가져오기
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();

--- a/src/main/java/com/fifo/compasstep/song/controller/SongController.java
+++ b/src/main/java/com/fifo/compasstep/song/controller/SongController.java
@@ -1,0 +1,26 @@
+package com.fifo.compasstep.song.controller;
+
+import com.fifo.compasstep.apipayload.ApiResponse;
+import com.fifo.compasstep.common.dto.StoreRequestDTO;
+import com.fifo.compasstep.common.dto.StoreResponseDTO;
+import com.fifo.compasstep.song.repository.SongRepository;
+import com.fifo.compasstep.song.service.SongService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+@RequestMapping("/api/song")
+@RequiredArgsConstructor
+public class SongController {
+    private final SongService songService;
+
+    @PostMapping("files/store")
+    public ApiResponse<StoreResponseDTO> storeSong(
+            @RequestBody StoreRequestDTO request) {
+        StoreResponseDTO result = songService.storeSong(request);
+        return ApiResponse.success(result);
+    }
+}

--- a/src/main/java/com/fifo/compasstep/song/controller/SongController.java
+++ b/src/main/java/com/fifo/compasstep/song/controller/SongController.java
@@ -10,8 +10,9 @@ import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
-@Controller
+@RestController
 @RequestMapping("/api/song")
 @RequiredArgsConstructor
 public class SongController {

--- a/src/main/java/com/fifo/compasstep/song/repository/CustomSongRepository.java
+++ b/src/main/java/com/fifo/compasstep/song/repository/CustomSongRepository.java
@@ -1,0 +1,4 @@
+package com.fifo.compasstep.song.repository;
+
+public interface CustomSongRepository {
+}

--- a/src/main/java/com/fifo/compasstep/song/repository/CustomSongRepositoryImpl.java
+++ b/src/main/java/com/fifo/compasstep/song/repository/CustomSongRepositoryImpl.java
@@ -1,0 +1,4 @@
+package com.fifo.compasstep.song.repository;
+
+public class CustomSongRepositoryImpl {
+}

--- a/src/main/java/com/fifo/compasstep/song/repository/SongRepository.java
+++ b/src/main/java/com/fifo/compasstep/song/repository/SongRepository.java
@@ -1,0 +1,9 @@
+package com.fifo.compasstep.song.repository;
+
+import com.fifo.compasstep.song.domain.Song;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SongRepository extends JpaRepository<Song, Integer> {
+    //Song save(Song song);
+
+}

--- a/src/main/java/com/fifo/compasstep/song/service/SongService.java
+++ b/src/main/java/com/fifo/compasstep/song/service/SongService.java
@@ -1,0 +1,45 @@
+package com.fifo.compasstep.song.service;
+
+import com.fifo.compasstep.apipayload.exceptions.handler.UserHandler;
+import com.fifo.compasstep.common.dto.StoreRequestDTO;
+import com.fifo.compasstep.common.dto.StoreResponseDTO;
+import com.fifo.compasstep.security.userDetails.UserUserDetails;
+import com.fifo.compasstep.song.domain.Song;
+import com.fifo.compasstep.song.repository.SongRepository;
+import com.fifo.compasstep.user.exceptions.UserErrorStatus;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SongService {
+    private final SongRepository songRepository;
+
+    public StoreResponseDTO storeSong(StoreRequestDTO request) {
+        // 현재 로그인된 사용자 정보 가져오기
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !(authentication.getPrincipal() instanceof UserUserDetails)) {
+            // 인증 정보가 없거나, 예상치 못한 Principal 타입인 경우 예외 처리
+            throw new UserHandler(UserErrorStatus.USER_NOT_FOUND); // 적절한 에러 상태 정의 필요
+        }
+        // 현재 로그인 된 사용자 정보 / 이름 / 파일 키 가져옴
+        UserUserDetails currentUserDetails = (UserUserDetails) authentication.getPrincipal();
+        String title = request.getTitle();
+        String fileKey = request.getFileKey();
+
+        Song song = Song.builder()
+                .title(title)
+                .s3FileKey(fileKey)
+                .user(currentUserDetails.getUser())
+                .build();
+        Song saved = songRepository.save(song);
+
+        return StoreResponseDTO.builder()
+                .content_id(saved.getId())
+                .build();
+    }
+}

--- a/src/main/java/com/fifo/compasstep/song/service/SongService.java
+++ b/src/main/java/com/fifo/compasstep/song/service/SongService.java
@@ -12,6 +12,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service
@@ -19,6 +20,7 @@ import org.springframework.stereotype.Service;
 public class SongService {
     private final SongRepository songRepository;
 
+    @Transactional
     public StoreResponseDTO storeSong(StoreRequestDTO request) {
         // 현재 로그인된 사용자 정보 가져오기
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();

--- a/src/main/java/com/fifo/compasstep/user/controller/UserController.java
+++ b/src/main/java/com/fifo/compasstep/user/controller/UserController.java
@@ -9,10 +9,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/user")
@@ -38,10 +35,23 @@ public class UserController {
         return ApiResponse.success(null);
     }
 
+    @DeleteMapping("/auth/signout")
+    public ApiResponse<Void> signout(HttpServletRequest request, HttpServletResponse response) {
+        userService.signout(request, response);
+        return ApiResponse.success(null);
+    }
+
     @PostMapping("/files/url")
     public ApiResponse<UserResponseDTO.generatePresignedUrlResponseDTO> generatePresignedUrl(
             UserRequestDTO.generatePresignedUrlRequestDTO request, HttpServletResponse response) {
         UserResponseDTO.generatePresignedUrlResponseDTO result = userService.generateUrl(request, response);
+        return ApiResponse.success(result);
+    }
+
+    @PostMapping("/files/download")
+    public ApiResponse<UserResponseDTO.downloadUrlResponseDTO> download(
+            @RequestBody UserRequestDTO.downloadUrlRequestDTO request) {
+        UserResponseDTO.downloadUrlResponseDTO result = userService.generateDownloadUrl(request);
         return ApiResponse.success(result);
     }
 }

--- a/src/main/java/com/fifo/compasstep/user/domain/User.java
+++ b/src/main/java/com/fifo/compasstep/user/domain/User.java
@@ -1,5 +1,6 @@
 package com.fifo.compasstep.user.domain;
 
+import com.fifo.compasstep.admin.enums.Role;
 import com.fifo.compasstep.chat.domain.Chat;
 import com.fifo.compasstep.common.domain.BaseEntity;
 import com.fifo.compasstep.lyrics.domain.Lyrics;
@@ -14,6 +15,7 @@ import org.hibernate.annotations.DynamicInsert;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 @Entity
 @Table(name = "users") // user로 설정하면 예약어와 충돌해 오류 발생, users로 변경
@@ -72,5 +74,19 @@ public class User extends BaseEntity {
         this.s3FileImage = s3FileImage;
         // status, isDeleted 등은 DB 기본값이나 @ColumnDefault를 따름
         this.isDeleted = false;
+    }
+
+    public void changeStatus(Status newStatus) {
+        this.status = newStatus;
+    }
+
+    public void anonymize() {
+        // 개인 식별 정보를 정해진 더미 값으로 변경
+        this.name = "탈퇴된 사용자" + this.name;
+        this.nickname = "탈퇴된 사용자" + this.nickname;
+        this.email = "탈퇴된 사용자" + this.email;
+        // 로그인 방지를 위해 비밀번호는 사용 불가능한 임의의 값으로 설정
+        this.status = Status.DELETED;
+        this.isDeleted = true;
     }
 }

--- a/src/main/java/com/fifo/compasstep/user/dto/UserRequestDTO.java
+++ b/src/main/java/com/fifo/compasstep/user/dto/UserRequestDTO.java
@@ -25,4 +25,15 @@ public class UserRequestDTO {
         @NonNull
         private String originalFileName;
     }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class downloadUrlRequestDTO {
+        @NonNull
+        private String fileKey;
+        @NonNull
+        private String originalFileName;
+    }
 }

--- a/src/main/java/com/fifo/compasstep/user/dto/UserResponseDTO.java
+++ b/src/main/java/com/fifo/compasstep/user/dto/UserResponseDTO.java
@@ -1,8 +1,6 @@
 package com.fifo.compasstep.user.dto;
 
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NonNull;
+import lombok.*;
 
 public class UserResponseDTO {
     @Getter
@@ -18,5 +16,14 @@ public class UserResponseDTO {
         private String presignedUrl;
         @NonNull
         private String fileKey;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class downloadUrlResponseDTO {
+        @NonNull
+        private String presignedUrl;
     }
 }

--- a/src/main/java/com/fifo/compasstep/user/repository/UserRepository.java
+++ b/src/main/java/com/fifo/compasstep/user/repository/UserRepository.java
@@ -2,12 +2,14 @@
 package com.fifo.compasstep.user.repository;
 
 import com.fifo.compasstep.user.domain.User;
+import com.fifo.compasstep.user.enums.Status;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
@@ -16,6 +18,8 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
     Optional<User> findById(Long id);
     boolean existsByNickname(String nickname);
+    List<User> findByStatusIn(List<Status> statuses);
+
     // 수정용 (벌크 업데이트)
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Transactional

--- a/src/main/java/com/fifo/compasstep/user/service/S3Service.java
+++ b/src/main/java/com/fifo/compasstep/user/service/S3Service.java
@@ -1,19 +1,24 @@
 package com.fifo.compasstep.user.service;
 
+import com.amazonaws.HttpMethod;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
+import com.amazonaws.services.s3.model.ResponseHeaderOverrides;
 import com.fifo.compasstep.user.dto.UserRequestDTO;
 import com.fifo.compasstep.user.dto.UserResponseDTO;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import java.net.URL;
+import java.time.Duration;
 import java.util.Date;
 import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class S3Service {
     private final AmazonS3 s3Client;
 
@@ -45,5 +50,31 @@ public class S3Service {
                 .fileKey(fileKey)
                 .build();
 
+    }
+
+    public String generatePresignedUrlForDownload(String objectKey, String originalFilename, long durationSeconds) {
+        log.info("Generating download URL for objectKey: {}", objectKey);
+        Date expiration = new Date();
+        long expTimeMillis = expiration.getTime();
+        expTimeMillis += Duration.ofSeconds(durationSeconds).toMillis(); // 만료 시간 계산
+        expiration.setTime(expTimeMillis);
+
+        // --- ▼▼▼ 다운로드를 위한 설정 ▼▼▼ ---
+        // 1. Response Header 설정: Content-Disposition을 attachment로 지정하여 다운로드 유도
+        ResponseHeaderOverrides responseHeaders = new ResponseHeaderOverrides();
+        responseHeaders.setContentDisposition("attachment; filename=\"" + originalFilename + "\"");
+
+        // 2. Presigned URL 생성 요청 객체 생성
+        GeneratePresignedUrlRequest generatePresignedUrlRequest =
+                new GeneratePresignedUrlRequest(bucketName, objectKey)
+                        .withMethod(HttpMethod.GET) // 읽기(다운로드)는 GET 메소드 사용
+                        .withExpiration(expiration)
+                        .withResponseHeaders(responseHeaders); // 다운로드 헤더 설정 적용
+        // --- ▲▲▲ ---
+
+        // 3. Presigned URL 생성
+        URL url = s3Client.generatePresignedUrl(generatePresignedUrlRequest);
+
+        return url.toString();
     }
 }

--- a/src/main/java/com/fifo/compasstep/user/service/UserService.java
+++ b/src/main/java/com/fifo/compasstep/user/service/UserService.java
@@ -1,5 +1,6 @@
 package com.fifo.compasstep.user.service;
 
+import com.fifo.compasstep.apipayload.exceptions.handler.UserHandler;
 import com.fifo.compasstep.security.jwt.JwtProperties;
 import com.fifo.compasstep.security.jwt.JwtTokenProvider;
 import com.fifo.compasstep.security.service.RefreshTokenService;
@@ -11,6 +12,7 @@ import com.fifo.compasstep.user.domain.User;
 import com.fifo.compasstep.user.dto.GoogleUserInfo;
 import com.fifo.compasstep.user.dto.UserRequestDTO;
 import com.fifo.compasstep.user.dto.UserResponseDTO;
+import com.fifo.compasstep.user.exceptions.UserErrorStatus;
 import com.fifo.compasstep.user.repository.UserRepository;
 import com.fifo.compasstep.user.tokenVerifier.GoogleTokenVerifier;
 import jakarta.servlet.http.HttpServletRequest;
@@ -21,7 +23,9 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
+import org.springframework.web.bind.annotation.RequestBody;
 
 import java.util.List;
 
@@ -111,8 +115,33 @@ public class UserService {
         cookieUtil.deleteCsrfTokenCookie(response);
     }
 
+    public void signout(HttpServletRequest request, HttpServletResponse response) {
+        // 현재 로그인된 사용자 정보 가져오기
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !(authentication.getPrincipal() instanceof UserUserDetails)) {
+            // 인증 정보가 없거나, 예상치 못한 Principal 타입인 경우 예외 처리
+            throw new UserHandler(UserErrorStatus.USER_NOT_FOUND); // 적절한 에러 상태 정의 필요
+        }
+        // 현재 로그인 된 사용자를 가져온 뒤 익명화
+        UserUserDetails currentUserDetails = (UserUserDetails) authentication.getPrincipal();
+        User currentuser = currentUserDetails.getUser();
+        currentuser.anonymize();
+
+        logout(request, response);
+    }
+
     public UserResponseDTO.generatePresignedUrlResponseDTO generateUrl(
             UserRequestDTO.generatePresignedUrlRequestDTO request, HttpServletResponse response) {
         return s3Service.generatePresignedUrl(request);
     }
+
+    public UserResponseDTO.downloadUrlResponseDTO generateDownloadUrl(
+            UserRequestDTO.downloadUrlRequestDTO request){
+        String presignedUrl = s3Service.generatePresignedUrlForDownload(request.getFileKey(), request.getOriginalFileName(), 3600);
+
+        return UserResponseDTO.downloadUrlResponseDTO.builder()
+                .presignedUrl(presignedUrl)
+                .build();
+    }
+
 }

--- a/src/main/java/com/fifo/compasstep/user/service/UserService.java
+++ b/src/main/java/com/fifo/compasstep/user/service/UserService.java
@@ -115,6 +115,7 @@ public class UserService {
         cookieUtil.deleteCsrfTokenCookie(response);
     }
 
+    @Transactional
     public void signout(HttpServletRequest request, HttpServletResponse response) {
         // 현재 로그인된 사용자 정보 가져오기
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
@@ -124,8 +125,11 @@ public class UserService {
         }
         // 현재 로그인 된 사용자를 가져온 뒤 익명화
         UserUserDetails currentUserDetails = (UserUserDetails) authentication.getPrincipal();
-        User currentuser = currentUserDetails.getUser();
-        currentuser.anonymize();
+        Long currentUserId = currentUserDetails.getUser().getId();
+        // 2. ID를 사용해 DB에서 User 객체를 '다시 조회'하여 managed 상태로 만듦
+        User currentUser = userRepository.findById(currentUserId)
+                .orElseThrow(() -> new UserHandler(UserErrorStatus.USER_NOT_FOUND));
+        currentUser.anonymize();
 
         logout(request, response);
     }


### PR DESCRIPTION
## 🔗 관련 이슈
Issue#32
---

## ✨ 변경 내용
유저 도메인의 전반적인 기능 구현
- s3로 업로드 후 메타데이터 저장 기능 구현
- s3 업로드용 프리사인드 url 발급 구현
- 유저 탈퇴 구현
- s3 다운로드용 프리사인드 url 발급 구현
- 유저 로그인/로그아웃 구현
---


## 🧪 테스트 방법
어떻게 동작을 검증했는지 작성해주세요.
- [ ] 유저 로그인/로그아웃
<img width="2108" height="625" alt="스크린샷 2025-10-21 181805" src="https://github.com/user-attachments/assets/91e6ba02-f61a-492a-adea-b7e397c5e9e5" />


- [ ] 업로드용 프리사인드 url
<img width="2122" height="689" alt="스크린샷 2025-10-21 181716" src="https://github.com/user-attachments/assets/5a006264-a9a4-4cb6-a1d2-7c263da787db" />

- [ ] 업로드 후 메타데이터 저장
업로드 성공(lyrics, song)
<img width="1054" height="306" alt="스크린샷 2025-10-26 175309" src="https://github.com/user-attachments/assets/14e8d24a-34c8-4169-b292-a5d25cd468a0" />
db내부
<img width="1506" height="138" alt="스크린샷 2025-10-26 175720" src="https://github.com/user-attachments/assets/7fd8d550-cb79-4fd0-861c-4db267172d93" />

- [ ] 유저 탈퇴
- 탈퇴 api실행
<img width="976" height="595" alt="스크린샷 2025-10-26 171234" src="https://github.com/user-attachments/assets/2a6b28df-88da-4abd-bbec-aae609dd7135" />

- db 내부(익명화)
<img width="1441" height="39" alt="스크린샷 2025-10-26 172200" src="https://github.com/user-attachments/assets/43efc2ac-0dea-4cd3-8bfe-5a2679d6ca1e" />

- [ ] s3다운로드용 프리사인드 url 발급
<img width="2133" height="376" alt="스크린샷 2025-10-26 170525" src="https://github.com/user-attachments/assets/7871043c-322a-4589-a33a-596de12cf144" />
- 프리사인드 url 접속 시(1시간 유효)
<img width="694" height="228" alt="스크린샷 2025-10-26 170610" src="https://github.com/user-attachments/assets/6a9d36db-2edd-4fbf-a75f-d39aebd375cd" />

---

## 👀 리뷰 포인트


---

## 📎 기타 참고 사항
리뷰에 도움이 될만한 추가 맥락, 스크린샷, 관련 문서 링크 등을 남겨주세요.
