### PR TITLE
[Feat] 스케줄링 기반 유저 배치삭제 구현

### DIFF
--- a/src/main/java/com/fifo/compasstep/chat/domain/Chat.java
+++ b/src/main/java/com/fifo/compasstep/chat/domain/Chat.java
@@ -2,6 +2,8 @@ package com.fifo.compasstep.chat.domain;
 
 import com.fifo.compasstep.common.domain.BaseEntity;
 import com.fifo.compasstep.user.domain.User;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -17,6 +19,7 @@ public class Chat extends BaseEntity {
     //userPKId
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private User user;
 
     @Column(nullable = false)

--- a/src/main/java/com/fifo/compasstep/config/SchedulingConfig.java
+++ b/src/main/java/com/fifo/compasstep/config/SchedulingConfig.java
@@ -1,0 +1,24 @@
+package com.fifo.compasstep.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+
+@Configuration
+@EnableScheduling
+public class SchedulingConfig {
+
+    /**
+     * 스케줄러 스레드풀 설정
+     */
+    @Bean(name = "taskScheduler")
+    public ThreadPoolTaskScheduler taskScheduler() {
+        ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+        scheduler.setPoolSize(2);                   // 동시에 돌 스케줄 작업 수
+        scheduler.setThreadNamePrefix("scheduler-");
+        scheduler.setRemoveOnCancelPolicy(true);   // 취소 시 큐에서 제거
+        scheduler.setAwaitTerminationSeconds(30);  // 종료 대기 시간
+        return scheduler;
+    }
+}

--- a/src/main/java/com/fifo/compasstep/guestComment/domain/GuestComment.java
+++ b/src/main/java/com/fifo/compasstep/guestComment/domain/GuestComment.java
@@ -2,6 +2,8 @@ package com.fifo.compasstep.guestComment.domain;
 
 import com.fifo.compasstep.common.domain.BaseEntity;
 import com.fifo.compasstep.post.domain.Post;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -19,6 +21,7 @@ public class GuestComment extends BaseEntity {
     //postPKId
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "post_id", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Post post;
 
     @Column(nullable = false)

--- a/src/main/java/com/fifo/compasstep/lyrics/domain/Lyrics.java
+++ b/src/main/java/com/fifo/compasstep/lyrics/domain/Lyrics.java
@@ -3,6 +3,8 @@ package com.fifo.compasstep.lyrics.domain;
 import com.fifo.compasstep.common.domain.BaseEntity;
 import com.fifo.compasstep.lyrics_analysis.domain.LyricsAnalysis;
 import com.fifo.compasstep.user.domain.User;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -20,6 +22,7 @@ public class Lyrics extends BaseEntity {
     //userPKId
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private User user;
 
     @Column(nullable = false)

--- a/src/main/java/com/fifo/compasstep/lyrics_analysis/domain/LyricsAnalysis.java
+++ b/src/main/java/com/fifo/compasstep/lyrics_analysis/domain/LyricsAnalysis.java
@@ -2,6 +2,8 @@ package com.fifo.compasstep.lyrics_analysis.domain;
 
 import com.fifo.compasstep.common.domain.BaseEntity;
 import com.fifo.compasstep.lyrics.domain.Lyrics;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -19,6 +21,7 @@ public class LyricsAnalysis extends BaseEntity {
     //lyricsPKId
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "lyrics_id", nullable = false, unique = true)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Lyrics lyrics;
 
     @Column(name = "analysis_result", nullable = false, columnDefinition = "jsonb")

--- a/src/main/java/com/fifo/compasstep/post/domain/Post.java
+++ b/src/main/java/com/fifo/compasstep/post/domain/Post.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fifo.compasstep.common.domain.BaseEntity;
 import com.fifo.compasstep.guestComment.domain.GuestComment;
 import com.fifo.compasstep.song.domain.Song;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 import jakarta.persistence.*;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
@@ -23,6 +25,7 @@ public class Post extends BaseEntity {
 
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "song_id", nullable = false, unique = true)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Song song;
 
     @Column(name = "share_summary", columnDefinition = "jsonb")

--- a/src/main/java/com/fifo/compasstep/reputationAnalysis/domain/ReputationAnalysis.java
+++ b/src/main/java/com/fifo/compasstep/reputationAnalysis/domain/ReputationAnalysis.java
@@ -2,6 +2,8 @@ package com.fifo.compasstep.reputationAnalysis.domain;
 
 import com.fifo.compasstep.common.domain.BaseEntity;
 import com.fifo.compasstep.user.domain.User;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -19,6 +21,7 @@ public class ReputationAnalysis extends BaseEntity {
     //userPKId
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private User user;
 
     @Column(name = "song_title", nullable = false)
@@ -32,10 +35,10 @@ public class ReputationAnalysis extends BaseEntity {
 
     @Column(name = "emotion_details", nullable = false, columnDefinition = "jsonb")
     private String emotionDetails;
+
     @Column(nullable = false, columnDefinition = "jsonb")
     private String keywords;
 
-    @Column(nullable = false, columnDefinition = "jsonb")
     public static ReputationAnalysis create(User user, String songTitle, String artistName, String sentimentSummary, String emotionDetails, String keywords) {
         ReputationAnalysis analysis = ReputationAnalysis.builder()
                 .user(user)

--- a/src/main/java/com/fifo/compasstep/song/domain/Song.java
+++ b/src/main/java/com/fifo/compasstep/song/domain/Song.java
@@ -3,6 +3,8 @@ package com.fifo.compasstep.song.domain;
 import com.fifo.compasstep.common.domain.BaseEntity;
 import com.fifo.compasstep.post.domain.Post;
 import com.fifo.compasstep.user.domain.User;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 import jakarta.persistence.*;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
@@ -17,6 +19,7 @@ public class Song extends BaseEntity {
     //userPKId
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private User user;
 
     @Column(nullable = false)

--- a/src/main/java/com/fifo/compasstep/user/job/UserHardDeleteJob.java
+++ b/src/main/java/com/fifo/compasstep/user/job/UserHardDeleteJob.java
@@ -1,0 +1,27 @@
+package com.fifo.compasstep.user.job;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class UserHardDeleteJob {
+
+    private final JdbcTemplate jdbc;
+
+    @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul") // 매일 00:00 KST
+    @Transactional
+    public void run() {
+        int deleted = jdbc.update("""
+            DELETE FROM users
+             WHERE is_deleted = true
+               AND updated_at <= NOW() - INTERVAL '3 days'
+        """);
+        log.info("Hard-deleted users: {}", deleted);
+    }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -6,7 +6,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: update   # update나 create 선택 가능
+      ddl-auto: update # update나 create 선택 가능
     show-sql: true
     properties:
       hibernate:


### PR DESCRIPTION
## 🔗 관련 이슈
해당 PR이 연결되는 이슈 번호를 명시하세요.  
예) Issue #41 

---

## ✨ 변경 내용
이번 PR에서 어떤 작업을 했는지 요약해주세요.
- domain 수정 cascade 추가
- UserHardDeleteJob 파일 추가
- SchedulingConfig 파일 추가

---

## 🧪 테스트 방법
어떻게 동작을 검증했는지 작성해주세요.
- [ ] cron 시간을 프로젝트 실행 후 2분 뒤로 설정하여 테스트
- [ ] 실제로 user와 연관된 데이터들이 날라가는지 확인
- [ ] 3일이 안된 유저는 삭제 안되는지 확인

---

## 👀 리뷰 포인트
리뷰어가 집중해서 봐줬으면 하는 부분을 적어주세요.
- domain cascade 추가한 것 문제없는지 확인 필요

---

## 📎 기타 참고 사항
리뷰에 도움이 될만한 추가 맥락, 스크린샷, 관련 문서 링크 등을 남겨주세요.
### 테스트 데이터
### [시간 되기전]
- User 테이블
<img width="1367" height="142" alt="image" src="https://github.com/user-attachments/assets/4b92ea29-0e6f-474e-8264-da249134e8ab" />
✓ id 값이 2, 4인 유저의 데이터가 삭제되어야 한다.

- Song 테이블
<img width="1105" height="193" alt="image" src="https://github.com/user-attachments/assets/7c064660-a9e8-4b76-8a50-9149bb0efa5e" />
✓ user_id 값이 2인 id값이 303, 305 데이터가 삭제되어야 한다.

- posts 테이블
<img width="1375" height="79" alt="image" src="https://github.com/user-attachments/assets/ea6652c9-75bf-49bc-a214-024aef74de62" />
✓ 삭제 되면 안된다.

- guest_comments 테이블
<img width="1049" height="170" alt="image" src="https://github.com/user-attachments/assets/a67b0806-e451-4466-982b-e53713cda3e0" />
✓ 삭제 되면 안된다.

- lyrics 테이블
<img width="1067" height="300" alt="image" src="https://github.com/user-attachments/assets/2c8158dd-9248-4338-9ea4-35f0d0706c25" />
✓user_id 값이 2, 4인 id값이 103, 108, 104, 107 데이터가 삭제되어야 한다.

- lyrics_analysis 테이블
<img width="1054" height="295" alt="image" src="https://github.com/user-attachments/assets/aa9a5f94-4c18-4f05-95d7-a1241f78f9db" />
✓ lyrics_id값이 103, 108, 104, 107인 id값이 203, 204, 208, 207 데이터가 삭제되어야한다.

- reputation_analysis 테이블
<img width="1382" height="250" alt="image" src="https://github.com/user-attachments/assets/3ad0709f-a0f5-429a-a1fe-f1a425cc5da8" />
✓ user_id값이 2, 4인 id값이 404, 405, 408인 데이터가 삭제되어야 한다.


### [배치 작업 시간이 되었을 때] - 삭제 작업 진행 후
- 삭제 로그
<img width="717" height="23" alt="image" src="https://github.com/user-attachments/assets/a3d10a70-24f1-4e8f-91e5-ac75a59dce87" />

- User 테이블
<img width="1372" height="148" alt="image" src="https://github.com/user-attachments/assets/393ea10d-3d55-42cb-803f-b4b16ec512a3" />
✓ user 테이블의 is_deleted, 3일 이상 넘어간 유저 삭제 완료

- Song 테이블
<img width="1111" height="181" alt="image" src="https://github.com/user-attachments/assets/ca449cbb-05ec-4b69-bf15-87df03ad176f" />
✓ id값이 303, 305 데이터 삭제완료

- posts 테이블
<img width="1376" height="88" alt="image" src="https://github.com/user-attachments/assets/e8a70634-2699-4ce4-8749-24db28543f7f" />
✓ 정상적으로 유지

- guest_comments 테이블
<img width="1056" height="245" alt="image" src="https://github.com/user-attachments/assets/6a4364ea-0722-434b-8512-fc60fd7a0470" />
✓ 정상적으로 유지

- lyrics 테이블
<img width="1064" height="296" alt="image" src="https://github.com/user-attachments/assets/4048ffa8-bfbf-4ada-9ff0-84eac74a11b1" />
✓ id값이 103, 108, 104, 107인 데이터 삭제완료

- lyrics_analysis 테이블
<img width="1047" height="276" alt="image" src="https://github.com/user-attachments/assets/01914021-72fe-4836-ad27-983cfe4040d1" />
✓ id값이 203, 204, 208, 207 데이터 삭제 완료

- reputation_analysis 테이블
<img width="1361" height="262" alt="image" src="https://github.com/user-attachments/assets/0c49ddf6-b98b-4b49-a880-a188ac067cef" />
✓ id값이 404, 405, 408인 데이터 삭제 완료

### 유저의 updated_at 시간이 3일이 안되었을 경우
- 배치 삭제 진행전 user 테이블
<img width="1379" height="147" alt="image" src="https://github.com/user-attachments/assets/703e27ad-dfa0-40a9-b24f-ee56fe505e73" />
✓ user_id가 2인 것만 삭제되고 4는 삭제되면 안된다.

- 배치 삭제 후 로그
<img width="718" height="32" alt="image" src="https://github.com/user-attachments/assets/bc161c7e-06e1-4216-adfd-193f9dbacf87" />

- 배치 삭제 진행 후 user 테이블
<img width="1365" height="118" alt="image" src="https://github.com/user-attachments/assets/db05bbda-1493-42c3-a418-5ef7c78f2462" />
✓ user_id가 2인 것만 삭제된 것을 확인