### PR TITLE
[Feat] prometheus를 이용한 정보 제공 API 생성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -76,6 +76,10 @@ dependencies {
 
     // 스웨거
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
+
+    // promethues
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'io.micrometer:micrometer-registry-prometheus'
 }
 
 tasks.named('test') {

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -1,0 +1,8 @@
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: 'spring'
+    metrics_path: /actuator/prometheus
+    static_configs:
+      - targets: ['host.docker.internal:8080']  # Linux면 호스트 IP/컨테이너 이름

--- a/src/main/java/com/fifo/compasstep/apipayload/exceptions/handler/MetricsHandler.java
+++ b/src/main/java/com/fifo/compasstep/apipayload/exceptions/handler/MetricsHandler.java
@@ -1,0 +1,10 @@
+package com.fifo.compasstep.apipayload.exceptions.handler;
+
+import com.fifo.compasstep.apipayload.code.BaseErrorCode;
+import com.fifo.compasstep.apipayload.exceptions.GeneralException;
+
+public class MetricsHandler extends GeneralException {
+    public MetricsHandler(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/fifo/compasstep/config/ExternalApiConfig.java
+++ b/src/main/java/com/fifo/compasstep/config/ExternalApiConfig.java
@@ -61,4 +61,16 @@ public class ExternalApiConfig {
                 .defaultHeader("Content-Type", "application/json")
                 .build();
     }
+
+    // Prometheus 클라이언트 추가
+    @Bean("prometheusClient")
+    public WebClient prometheusClient() {
+        var cfg = props.getPrometheus();
+        return WebClient.builder()
+                .baseUrl(cfg.getBaseUrl())  // base-url 설정
+                .clientConnector(new ReactorClientHttpConnector(
+                        HttpClient.create().responseTimeout(Duration.ofMillis(cfg.getTimeoutMs()))
+                ))
+                .build();
+    }
 }

--- a/src/main/java/com/fifo/compasstep/config/ExternalApiProperties.java
+++ b/src/main/java/com/fifo/compasstep/config/ExternalApiProperties.java
@@ -17,7 +17,6 @@ public class ExternalApiProperties {
         private String clientId;
         private String clientSecret;
         private Integer timeoutMs = 5000;
-
     }
 
     @Setter
@@ -26,19 +25,25 @@ public class ExternalApiProperties {
         private String baseUrl;
         private String apiKey;
         private Integer timeoutMs = 5000;
-
     }
 
     @Getter
     @Setter
-    public static class Fastapi {              // ← 추가
+    public static class Fastapi {
         private String baseUrl;
         private int timeoutMs = 5000;
     }
 
+    // Prometheus 관련 설정 추가
+    @Getter
+    @Setter
+    public static class Prometheus {
+        private String baseUrl;  // Prometheus의 base URL
+        private int timeoutMs = 5000;  // 타임아웃 설정
+    }
 
     private Spotify spotify;
     private Youtube youtube;
     private Fastapi fastapi;
+    private Prometheus prometheus;  // Prometheus 설정 객체
 }
-

--- a/src/main/java/com/fifo/compasstep/metrics/client/MetricsClient.java
+++ b/src/main/java/com/fifo/compasstep/metrics/client/MetricsClient.java
@@ -1,0 +1,28 @@
+package com.fifo.compasstep.metrics.client;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class MetricsClient {
+
+    // Prometheus 클라이언트를 주입받음
+    @Qualifier("prometheusClient")
+    private final WebClient prometheusClient;
+
+    // Prometheus 쿼리 실행 메서드
+    public Map<String, Object> queryMetrics(String query) {
+        return prometheusClient.get()
+                .uri(uri -> uri.path("/api/v1/query")
+                        .queryParam("query", query)
+                        .build())
+                .retrieve()
+                .bodyToMono(Map.class)  // Map으로 응답을 받도록 수정
+                .block();
+    }
+}

--- a/src/main/java/com/fifo/compasstep/metrics/constants/ExcludedUrls.java
+++ b/src/main/java/com/fifo/compasstep/metrics/constants/ExcludedUrls.java
@@ -1,0 +1,16 @@
+package com.fifo.compasstep.metrics.constants;
+
+import java.util.List;
+
+public class ExcludedUrls {
+
+    // 제외할 URL 목록을 상수로 정의 (와일드카드 경로 포함)
+    public static final List<String> EXCLUDED_URLS = List.of(
+            "/actuator/prometheus",
+            "/swagger-ui*/**",
+            "/swagger-ui*/*swagger-initializer.js",
+            "/v3/api-docs",
+            "/v3/api-docs/swagger-config",
+            "UNKNOWN"
+    );
+}

--- a/src/main/java/com/fifo/compasstep/metrics/controller/MetricsController.java
+++ b/src/main/java/com/fifo/compasstep/metrics/controller/MetricsController.java
@@ -1,0 +1,34 @@
+package com.fifo.compasstep.metrics.controller;
+
+import com.fifo.compasstep.apipayload.ApiResponse;
+import com.fifo.compasstep.metrics.dto.ApiCountDto;
+import com.fifo.compasstep.metrics.dto.ApiLatencyDto;
+import com.fifo.compasstep.metrics.service.MetricsService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/admin")  // /api/admin 경로로만 접근 가능, 관리자만 접근할 수 있음
+public class MetricsController {
+
+    private final MetricsService metricsService;
+
+    // API 호출 횟수 반환 (ROOT 및 GENERAL 관리자만 접근 가능)
+    @GetMapping("/metrics/api-count")
+    public ApiResponse<List<ApiCountDto>> getApiCount() {
+        List<ApiCountDto> apiCount = metricsService.getApiCount();
+        return ApiResponse.success(apiCount);
+    }
+
+    // API 지연 시간 반환 (ROOT 및 GENERAL 관리자만 접근 가능)
+    @GetMapping("/metrics/api-latency")
+    public ApiResponse<List<ApiLatencyDto>> getApiLatency() {
+        List<ApiLatencyDto> apiLatency = metricsService.getApiLatency();
+        return ApiResponse.success(apiLatency);
+    }
+}

--- a/src/main/java/com/fifo/compasstep/metrics/dto/ApiCountDto.java
+++ b/src/main/java/com/fifo/compasstep/metrics/dto/ApiCountDto.java
@@ -1,0 +1,21 @@
+package com.fifo.compasstep.metrics.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+public class ApiCountDto {
+    // getters and setters
+    @Setter
+    private String apiPath;
+    private Double count;
+
+    public ApiCountDto(String apiPath, Double count) {
+        this.apiPath = apiPath;
+        this.count = count;
+    }
+
+    public void setCount(int count) {
+        this.count = (double) count;
+    }
+}

--- a/src/main/java/com/fifo/compasstep/metrics/dto/ApiLatencyDto.java
+++ b/src/main/java/com/fifo/compasstep/metrics/dto/ApiLatencyDto.java
@@ -1,0 +1,18 @@
+package com.fifo.compasstep.metrics.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Setter
+@Getter
+public class ApiLatencyDto {
+    // getters and setters
+    private String apiPath;
+    private double latency;
+
+    public ApiLatencyDto(String apiPath, double latency) {
+        this.apiPath = apiPath;
+        this.latency = latency;
+    }
+
+}

--- a/src/main/java/com/fifo/compasstep/metrics/exceptions/MetricsErrorStatus.java
+++ b/src/main/java/com/fifo/compasstep/metrics/exceptions/MetricsErrorStatus.java
@@ -1,0 +1,39 @@
+package com.fifo.compasstep.metrics.exceptions;
+
+import com.fifo.compasstep.apipayload.code.BaseErrorCode;
+import com.fifo.compasstep.apipayload.code.ErrorReasonDTO;
+import org.springframework.http.HttpStatus;
+
+public enum MetricsErrorStatus implements BaseErrorCode {
+
+    INVALID_REQUEST(HttpStatus.BAD_REQUEST, 400, "잘못된 요청입니다."),
+    EXTERNAL_API_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 500, "외부 API 호출 중 오류가 발생했습니다."),
+    TIMEOUT_ERROR(HttpStatus.GATEWAY_TIMEOUT, 504, "요청이 시간 초과되었습니다.");
+
+    private final HttpStatus status;
+    private final int code;
+    private final String message;
+
+    MetricsErrorStatus(HttpStatus status, int code, String message) {
+        this.status = status;
+        this.code = code;
+        this.message = message;
+    }
+
+    @Override
+    public ErrorReasonDTO getReason() {
+        return ErrorReasonDTO.builder()
+                .message(message)
+                .code(code)
+                .build();
+    }
+
+    @Override
+    public ErrorReasonDTO getReasonHttpStatus() {
+        return ErrorReasonDTO.builder()
+                .message(message)
+                .code(code)
+                .httpStatus(status)
+                .build();
+    }
+}

--- a/src/main/java/com/fifo/compasstep/metrics/service/MetricsService.java
+++ b/src/main/java/com/fifo/compasstep/metrics/service/MetricsService.java
@@ -1,0 +1,128 @@
+package com.fifo.compasstep.metrics.service;
+
+import com.fifo.compasstep.metrics.client.MetricsClient;
+import com.fifo.compasstep.metrics.dto.ApiCountDto;
+import com.fifo.compasstep.metrics.dto.ApiLatencyDto;
+import com.fifo.compasstep.metrics.utils.MetricsUtils;  // 유틸리티 클래스 임포트
+import com.fifo.compasstep.metrics.constants.ExcludedUrls;  // 상수 클래스 임포트
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MetricsService {
+
+    private final MetricsClient metricsClient;
+    // API 호출 횟수 가져오기 (내림차순)
+    public List<ApiCountDto> getApiCount() {
+        // 1시간 동안의 요청 횟수 증가를 계산
+        String query = "sum by (uri, method) (increase(http_server_requests_seconds_count[1h]))";
+        Map<String, Object> result = metricsClient.queryMetrics(query);  // Map으로 받음
+
+        log.info("API Count Result: {}", result);  // 쿼리 결과 로그 출력
+
+        List<ApiCountDto> apiCount = new ArrayList<>();
+
+        Map<String, Object> data = (Map<String, Object>) result.get("data");
+        if (data != null) {
+            List<Map<String, Object>> resultList = (List<Map<String, Object>>) data.get("result");
+
+            if (resultList == null || resultList.isEmpty()) {
+                log.warn("No data found for the query: {}", query);
+                return apiCount;  // 빈 데이터가 있으면 빈 리스트 반환
+            }
+
+            // resultList에서 api_path와 count 값을 추출
+            for (Map<String, Object> entry : resultList) {
+                String apiPath = MetricsUtils.extractMetricToString(entry);  // metric 처리
+
+                // 특정 URL을 제외
+                if (MetricsUtils.shouldExcludeUrl(apiPath, ExcludedUrls.EXCLUDED_URLS)) {
+                    continue;  // 제외할 URL인 경우, 해당 항목을 건너뜀
+                }
+
+                List<Object> value = (List<Object>) entry.get("value");
+
+                Double parsedValue = MetricsUtils.extractValue(value);
+                if (parsedValue != null) {
+                    // 소수점 제거: 호출 횟수를 정수로 변환
+                    int countValue = parsedValue.intValue();  // 소수점 이하 버리기
+                    apiCount.add(new ApiCountDto(apiPath, (double) countValue));  // 정수로 처리
+                }
+            }
+        }
+
+        // 내림차순 정렬 유지 (숫자 내림차순)
+        apiCount.sort(Comparator.comparing(ApiCountDto::getCount).reversed());
+
+        return apiCount;
+    }
+
+    // API 지연 시간 가져오기 (오름차순)  -90일간
+    public List<ApiLatencyDto> getApiLatency() {
+        // 둘을 나눠서 지연시간 계산
+        String sumQuery = "sum by (uri, method) (increase(http_server_requests_seconds_sum[1h]))"; // 1시간 동안 API 요청에 소요된 총 시간
+        String countQuery = "sum by (uri, method) (increase(http_server_requests_seconds_count[1h]))"; // 1시간 동안의 요청 횟수 증가를 계산
+
+        log.info("Executing Sum Query: {}", sumQuery);
+        log.info("Executing Count Query: {}", countQuery);
+
+        Map<String, Object> sumResult = metricsClient.queryMetrics(sumQuery);
+        Map<String, Object> countResult = metricsClient.queryMetrics(countQuery);
+
+        log.info("Sum Result: {}", sumResult);
+        log.info("Count Result: {}", countResult);
+
+        List<ApiLatencyDto> apiLatency = new ArrayList<>();
+
+        Map<String, Object> sumData = (Map<String, Object>) sumResult.get("data");
+        Map<String, Object> countData = (Map<String, Object>) countResult.get("data");
+
+        if (sumData != null && countData != null) {
+            List<Map<String, Object>> sumList = (List<Map<String, Object>>) sumData.get("result");
+            List<Map<String, Object>> countList = (List<Map<String, Object>>) countData.get("result");
+
+            for (Map<String, Object> sumEntry : sumList) {
+                String apiPath = MetricsUtils.extractMetricToString(sumEntry);  // metric 처리
+
+                // 특정 URL을 제외
+                if (MetricsUtils.shouldExcludeUrl(apiPath, ExcludedUrls.EXCLUDED_URLS)) {
+                    continue;  // 제외할 URL인 경우, 해당 항목을 건너뜀
+                }
+
+                Object sumValue = sumEntry.get("value");
+
+                if (sumValue instanceof List) {
+                    List<Object> sumValues = (List<Object>) sumValue;
+                    Double latency = MetricsUtils.parseDoubleValue(sumValues.get(1));
+
+                    for (Map<String, Object> countEntry : countList) {
+                        if (countEntry.get("metric").toString().equals(apiPath)) {
+                            Object countValue = countEntry.get("value");
+                            Double count = MetricsUtils.parseDoubleValue(((List<Object>) countValue).get(1));
+
+                            if (latency != null && count != null && count != 0) {
+                                double latencyPerRequest = latency / count; // 지연 시간 계산
+                                apiLatency.add(new ApiLatencyDto(apiPath, latencyPerRequest));
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        log.info("Final API Latency List: {}", apiLatency);
+
+        // 오름차순으로 정렬 (지연 시간이 적은 순서대로)
+        apiLatency.sort(Comparator.comparing(ApiLatencyDto::getLatency));
+
+        return apiLatency;
+    }
+}

--- a/src/main/java/com/fifo/compasstep/metrics/utils/MetricsUtils.java
+++ b/src/main/java/com/fifo/compasstep/metrics/utils/MetricsUtils.java
@@ -1,0 +1,51 @@
+package com.fifo.compasstep.metrics.utils;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+public class MetricsUtils {
+
+    // Double로 변환하는 유틸리티 함수
+    public static Double parseDoubleValue(Object value) {
+        if (value instanceof String) {
+            try {
+                return Double.parseDouble((String) value);
+            } catch (NumberFormatException e) {
+                log.error("Error parsing value to Double: {}", value);
+                return null;  // 오류가 발생하면 null 반환
+            }
+        } else if (value instanceof Number) {
+            return ((Number) value).doubleValue();
+        } else {
+            log.error("Unexpected value type: {}", value.getClass());
+            return null;
+        }
+    }
+
+    // metric에서 apiPath를 추출하는 유틸리티 함수
+    public static String extractMetricToString(Map<String, Object> entry) {
+        Map<String, Object> metric = (Map<String, Object>) entry.get("metric");
+        return metric != null ? metric.toString() : "";
+    }
+
+    // value에서 count를 추출하는 유틸리티 함수
+    public static Double extractValue(List<Object> value) {
+        if (value != null && value.size() > 1) {
+            return parseDoubleValue(value.get(1));  // 두 번째 값이 count 또는 latency 값
+        }
+        return null;
+    }
+
+    // 특정 URL을 제외한 리스트 반환 (필터링 함수)
+    public static boolean shouldExcludeUrl(String apiPath, List<String> excludedUrls) {
+        for (String excludedUrl : excludedUrls) {
+            if (apiPath.contains(excludedUrl)) {
+                return true;  // 제외할 URL을 찾으면 true 반환
+            }
+        }
+        return false;  // 제외할 URL이 없다면 false
+    }
+}

--- a/src/main/java/com/fifo/compasstep/security/config/SecurityConfig.java
+++ b/src/main/java/com/fifo/compasstep/security/config/SecurityConfig.java
@@ -76,6 +76,9 @@ public class SecurityConfig {
                                 "/swagger-resources/**"
                         ).permitAll()
 
+                        // 프로메테우스 공개
+                        .requestMatchers("/actuator/health", "/actuator/prometheus").permitAll()
+
                         // 게스트 공개 (예시)
                         .requestMatchers(HttpMethod.GET, "/posts/**").permitAll()
                         .requestMatchers(HttpMethod.POST, "/posts/*/comments").permitAll()

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -41,3 +41,24 @@ spring:
           auth: true
           starttls:
             enable: true
+
+# Prometheus
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info,prometheus
+  endpoint:
+    health:
+      show-details: always
+  metrics:
+    tags:
+      application: ${spring.application.name:app}
+    distribution:
+      # p95/p99 보려면 히스토그램/퍼센타일 활성화 권장
+      percentiles:
+        all: 0.5,0.9,0.95,0.99
+      percentiles-histogram:
+        http.server.requests: true
+      slo:
+        http.server.requests: 100ms,300ms,500ms,1s,2s,5s


### PR DESCRIPTION
## 🔗 관련 이슈
해당 PR이 연결되는 이슈 번호를 명시하세요.  
예) Issue #43 

---

## ✨ 변경 내용
이번 PR에서 어떤 작업을 했는지 요약해주세요.
- promethues 관련 의존성 추가
- 프로메테우스 접속 주소 추가
- promethues 클라이언트 추가
- 1시간 기준 API 호출횟수, API 지연시간 기능 개발

---

## 🧪 테스트 방법
어떻게 동작을 검증했는지 작성해주세요.
- [ ] promethues가 정상적으로 작동하는지 직접 접속
- [ ] 실제로 api호출 시 값이 증가하는 지 확인
- [ ] 지연시간은 특수문자 인코딩, url길이 문제로 두개로 나눠서 계산하기 때문에 합쳐서 쿼리 보낼때와의 값 비교

---

## 👀 리뷰 포인트
리뷰어가 집중해서 봐줬으면 하는 부분을 적어주세요.
- 여기에 적어주세요

---

## 📎 기타 참고 사항
리뷰에 도움이 될만한 추가 맥락, 스크린샷, 관련 문서 링크 등을 남겨주세요.
### Swagger 테스트 (api-count)
- 한번 더 누르기 전
<img width="807" height="427" alt="image" src="https://github.com/user-attachments/assets/ede28876-c713-4709-9e19-bc0317fe0bd4" />

- 한번 더 누른 후
<img width="807" height="427" alt="image" src="https://github.com/user-attachments/assets/1f0af0ce-0147-48db-ae8a-36f367f2831b" />
✓ 호출 횟수가 증가한 것을 확인 가능

### Swagger 테스트(api-latency)
<img width="1346" height="836" alt="image" src="https://github.com/user-attachments/assets/383d6c77-bf8a-4f94-a0b2-cbe8dfa29b34" />
✓ promethues에서 직접 호출한 것과 쿼리문을 나눠서 보낸 후 계산한 값이 같은 것을 확인 가능
✓ 특정 url은 제외하도록 설정하여 api-latency의 호출 결과는 스웨거 url이 없는 것을 확인 가능