### PR TITLE
[Fix] 대중 평판 분석 내용을 실수로도 반환하도록 변경

### DIFF
--- a/src/main/java/com/fifo/compasstep/reputationAnalysis/dto/response/ReputationDetailResponseDto.java
+++ b/src/main/java/com/fifo/compasstep/reputationAnalysis/dto/response/ReputationDetailResponseDto.java
@@ -11,8 +11,8 @@ public record ReputationDetailResponseDto(
         Long historyId,
         String songTitle,
         String artistName,
-        Map<String, Integer> sentimentSummary, // {"positive":85,"negative":10,"neutral":5}
-        Map<String, Integer> emotionDetails,   // {"joy":50,"sadness":5,...}
+        Map<String, Double> sentimentSummary, // {"positive":85,"negative":10,"neutral":5}
+        Map<String, Double> emotionDetails,   // {"joy":50,"sadness":5,...}
         List<String> keywords,                 // ["달달하다","목소리",...]
         Instant createdAt
 ) {}

--- a/src/main/java/com/fifo/compasstep/reputationAnalysis/service/ReputationAnalysisService.java
+++ b/src/main/java/com/fifo/compasstep/reputationAnalysis/service/ReputationAnalysisService.java
@@ -50,8 +50,8 @@ public class ReputationAnalysisService {
         ReputationAnalysis entity = repo.findById(historyId)
                 .orElseThrow(() -> new ReputationAnalysisHandler(ReputationErrorStatus.HISTORY_NOT_FOUND));
 
-        Map<String, Integer> sentiment = parseObject(entity.getSentimentSummary());
-        Map<String, Integer> emotions  = parseObject(entity.getEmotionDetails());
+        Map<String, Double> sentiment = parseObject(entity.getSentimentSummary());
+        Map<String, Double> emotions  = parseObject(entity.getEmotionDetails());
         List<String> keywords          = parseArray(entity.getKeywords());
 
         return ReputationDetailResponseDto.builder()
@@ -77,7 +77,7 @@ public class ReputationAnalysisService {
     }
 
     /* ===== JSON 유틸 ===== */
-    private Map<String, Integer> parseObject(String json) {
+    private Map<String, Double> parseObject(String json) {
         try {
             return objectMapper.readValue(json, new TypeReference<>() {});
         } catch (Exception e) {


### PR DESCRIPTION
1. DTO Map의 Integer을 Double로 수정
2. DTO 변경에 맞게 service 수정

## 🔗 관련 이슈
해당 PR이 연결되는 이슈 번호를 명시하세요.  
예) Issue #46 

---

## ✨ 변경 내용
이번 PR에서 어떤 작업을 했는지 요약해주세요.
- DTO Map의 Integer을 Double로 수정
- DTO 변경에 맞게 service 수정

---

## 🧪 테스트 방법
어떻게 동작을 검증했는지 작성해주세요.
- [ ] 실수 값 나오는지 스웨거로 확인

---

## 👀 리뷰 포인트
리뷰어가 집중해서 봐줬으면 하는 부분을 적어주세요.
- 여기에 적어주세요

---

## 📎 기타 참고 사항
리뷰에 도움이 될만한 추가 맥락, 스크린샷, 관련 문서 링크 등을 남겨주세요.
### 스웨거 테스트
<img width="1417" height="675" alt="image" src="https://github.com/user-attachments/assets/fa65e40a-8220-41d8-aacf-64bec891f4b2" />
