### PR TITLE
[Feat] 관리자 대시보드 구현

### DIFF
--- a/src/main/java/com/fifo/compasstep/admin/controller/AdminController.java
+++ b/src/main/java/com/fifo/compasstep/admin/controller/AdminController.java
@@ -113,4 +113,10 @@ public class AdminController {
         adminService.unbanUser(userPKId);
         return ApiResponse.success(null);
     }
+
+    @GetMapping("/users/dashboard")
+    public ApiResponse<AdminResponseDTO.dashboardResponseDTO> dashboard() {
+        AdminResponseDTO.dashboardResponseDTO result = adminService.getDashboard();
+        return ApiResponse.success(result);
+    }
 }

--- a/src/main/java/com/fifo/compasstep/admin/dto/AdminResponseDTO.java
+++ b/src/main/java/com/fifo/compasstep/admin/dto/AdminResponseDTO.java
@@ -66,4 +66,14 @@ public class AdminResponseDTO {
         private Boolean isGuardrailed;
     }
 
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class dashboardResponseDTO {
+        private Long totalUser;
+        private Long maliciousUser;
+        private Long bannedUser;
+    }
+
 }

--- a/src/main/java/com/fifo/compasstep/admin/service/AdminService.java
+++ b/src/main/java/com/fifo/compasstep/admin/service/AdminService.java
@@ -358,6 +358,17 @@ public class AdminService {
         user.changeStatus(Status.NORMAL);
     }
 
+    public AdminResponseDTO.dashboardResponseDTO getDashboard() {
+        Long totalUser = userRepository.countByStatusNot(Status.DELETED);
+        Long maliciousUser = userRepository.countByStatus(Status.SUSPENDED);
+        Long bannedUser = userRepository.countByStatus(Status.BLOCKED);
+        return AdminResponseDTO.dashboardResponseDTO.builder()
+                .totalUser(totalUser)
+                .maliciousUser(maliciousUser)
+                .bannedUser(bannedUser)
+                .build();
+    }
+
     private Map<String, String> makeTemPassword() {
         Map<String, String> tempPassword = new HashMap<>();
         String temp = UUID.randomUUID().toString().substring(0, 8);

--- a/src/main/java/com/fifo/compasstep/user/repository/UserRepository.java
+++ b/src/main/java/com/fifo/compasstep/user/repository/UserRepository.java
@@ -20,6 +20,9 @@ public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByNickname(String nickname);
     List<User> findByStatusIn(List<Status> statuses);
 
+    Long countByStatusNot(Status status);
+    Long countByStatus(Status status);
+
     // 수정용 (벌크 업데이트)
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Transactional


### PR DESCRIPTION
## 🔗 관련 이슈
Issue #51

---

## ✨ 변경 내용
- 관리자 대시보드 기능 중 사용자 유형별 회원 수 조회 기능 구현
---

## 🧪 테스트 방법
어떻게 동작을 검증했는지 작성해주세요.
- [ ] 데이터베이스 상에 저장된 사용자들
(삭제대기1, 노말1, 차단1, 정지1)
이 중 총 사용자는 삭제대기를 제외한 3, 차단과 정지는 각각 1명씩 나와야 합니다.
<img width="1453" height="195" alt="스크린샷 2025-11-04 161030" src="https://github.com/user-attachments/assets/91c32505-b752-4c88-a7b1-f8572b6e2cb8" />

- 실제 결과

<img width="1307" height="681" alt="image" src="https://github.com/user-attachments/assets/1e396593-3759-4a16-acb0-875bf6a1d819" />

---

## 👀 리뷰 포인트
리뷰어가 집중해서 봐줬으면 하는 부분을 적어주세요.
- 여기에 적어주세요

---

## 📎 기타 참고 사항
리뷰에 도움이 될만한 추가 맥락, 스크린샷, 관련 문서 링크 등을 남겨주세요.
