### PR TITLE
[Feat] rabbitmq, redis pub/sub 임시구현

### DIFF
--- a/src/main/java/com/fifo/compasstep/rabbitmq/config/RabbitMQConfig.java
+++ b/src/main/java/com/fifo/compasstep/rabbitmq/config/RabbitMQConfig.java
@@ -1,0 +1,28 @@
+package com.fifo.compasstep.rabbitmq.config;
+
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
+import org.springframework.amqp.support.converter.MessageConverter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RabbitMQConfig {
+
+    // 1. JSON 메시지 컨버터 Bean 생성
+    @Bean
+    public MessageConverter jsonMessageConverter() {
+        return new Jackson2JsonMessageConverter();
+    }
+
+    // 2. RabbitTemplate Bean 생성
+    //    스프링이 자동으로 생성한 ConnectionFactory를 파라미터로 주입받는다.
+    @Bean
+    public RabbitTemplate rabbitTemplate(ConnectionFactory connectionFactory) {
+        RabbitTemplate rabbitTemplate = new RabbitTemplate(connectionFactory);
+        // 위에서 만든 JSON 메시지 컨버터를 RabbitTemplate에 설정
+        rabbitTemplate.setMessageConverter(jsonMessageConverter());
+        return rabbitTemplate;
+    }
+}

--- a/src/main/java/com/fifo/compasstep/rabbitmq/service/RabbitMQService.java
+++ b/src/main/java/com/fifo/compasstep/rabbitmq/service/RabbitMQService.java
@@ -1,0 +1,50 @@
+package com.fifo.compasstep.rabbitmq.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.amqp.core.Message;
+import org.springframework.amqp.core.MessageProperties;
+import org.springframework.amqp.core.MessagePropertiesBuilder;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+@Service
+public class RabbitMQService {
+    @Autowired
+    private RabbitTemplate rabbitTemplate;
+
+    @Autowired
+    private ObjectMapper objectMapper; // JSON 변환을 위해 ObjectMapper 주입
+
+    public void sendRetrainingTask(String jobId) throws Exception {
+        String exchangeName = "ai_tasks_exchange";
+        String routingKey = "retrain.start";
+        String taskName = "tasks.start_retraining";
+
+        // 1. Celery 메시지 본문 생성 (이전과 동일)
+        Map<String, String> kwargs = new HashMap<>();
+        kwargs.put("jobId", jobId);
+        kwargs.put("dataSource", "all_user_comments");
+
+        Object[] body = {Collections.emptyList(), kwargs, Collections.emptyMap()};
+        String bodyJson = objectMapper.writeValueAsString(body);
+
+        // 2. MessagePropertiesBuilder를 사용하여 속성 설정 (수정된 부분)
+        MessageProperties properties = MessagePropertiesBuilder.newInstance()
+                .setContentType("application/json") // "application/json"
+                .setContentEncoding("UTF-8")
+                .setHeader("task", taskName)
+                .setHeader("id", jobId)
+                .build();
+
+        // 3. 최종 메시지 생성 및 전송 (이전과 동일)
+        Message message = new Message(bodyJson.getBytes(), properties);
+        rabbitTemplate.send(exchangeName, routingKey, message);
+
+        System.out.println("Celery 형식으로 작업 발행 완료: " + jobId);
+    }
+}

--- a/src/main/java/com/fifo/compasstep/rabbitmq/service/TestController.java
+++ b/src/main/java/com/fifo/compasstep/rabbitmq/service/TestController.java
@@ -1,4 +1,4 @@
-/*package com.fifo.compasstep.rabbitmq.service;
+package com.fifo.compasstep.rabbitmq.service;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
@@ -33,4 +33,3 @@ public class TestController {
         return ResponseEntity.ok("AI retraining task has been queued with Job ID: " + jobId);
     }
 }
- */


### PR DESCRIPTION
## 🔗 관련 이슈
Issue #54

---

## ✨ 변경 내용
- rabbitmqservice, rabbitmqconfig구현

---

## 🧪 테스트 방법
- [ ] 우선 임시 api http://localhost:8080/api/tasks/retrain/start에 api를 호출할 경우 job id를 받습니다
---
<img width="1922" height="1058" alt="스크린샷 2025-11-08 121524" src="https://github.com/user-attachments/assets/7613059e-9909-44a9-a6b6-e9b0e8d29802" />
- 자바쪽 job id
<img width="867" height="353" alt="스크린샷 2025-11-08 121532" src="https://github.com/user-attachments/assets/b7a0ef94-e3d7-4c04-805d-1a4de7d15208" />

- [ ] 이후 파이썬 서버쪽에서 해당 job를 처리합니다(여기서는 임시로 10초간의 sleep후 메세지를 보내도록 구현하였습니다)
<img width="1823" height="325" alt="스크린샷 2025-11-08 121559" src="https://github.com/user-attachments/assets/ab582196-fd59-4f43-be75-c531c915c09d" />

- [ ] 10초 후 자바쪽으로 redis pub/sub을 통해 전달됩니다.
<img width="1602" height="72" alt="스크린샷 2025-11-08 121609" src="https://github.com/user-attachments/assets/eeb94ac0-96b6-4a5d-abde-a0aff6d53bfa" />


## 👀 리뷰 포인트
리뷰어가 집중해서 봐줬으면 하는 부분을 적어주세요.
- 여기에 적어주세요

---

## 📎 기타 참고 사항
리뷰에 도움이 될만한 추가 맥락, 스크린샷, 관련 문서 링크 등을 남겨주세요.
