### PR TITLE
[Fix] admin리스트 조회 시 id값도 같이 가져오도록 변경

### DIFF
--- a/src/main/java/com/fifo/compasstep/admin/dto/AdminResponseDTO.java
+++ b/src/main/java/com/fifo/compasstep/admin/dto/AdminResponseDTO.java
@@ -31,6 +31,7 @@ public class AdminResponseDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class AdminInfoDTO {
+        private Long id;
         private String nickname;
         private String email;
     }

--- a/src/main/java/com/fifo/compasstep/admin/service/AdminService.java
+++ b/src/main/java/com/fifo/compasstep/admin/service/AdminService.java
@@ -290,6 +290,7 @@ public class AdminService {
         // 2. Admin 엔티티 리스트를 AdminInfoDTO 리스트로 변환 (Java Stream API 사용)
         List<AdminResponseDTO.AdminInfoDTO> adminInfoDTOs = adminEntities.stream()
                 .map(admin -> AdminResponseDTO.AdminInfoDTO.builder()
+                        .id(admin.getId())
                         .nickname(admin.getName()) // 엔티티의 name 필드를 nickname으로 매핑
                         .email(admin.getEmail())
                         .build())


### PR DESCRIPTION

## 🔗 관련 이슈
해당 PR이 연결되는 이슈 번호를 명시하세요.  
예) Issue #56 

---

## ✨ 변경 내용
이번 PR에서 어떤 작업을 했는지 요약해주세요.
- AdminResponseDTO 파일 수정(id 추가)
- AdminService 파일 수정(getAllAdmins 함수에서 엔티티 리스트를 AdminInfoDTO 리스트로 변환하는 과정에서 id값도 넣도록 수정)
---

## 🧪 테스트 방법
어떻게 동작을 검증했는지 작성해주세요.
- [ ] swagger 테스트 시 id값 나오는지 확인

---

## 👀 리뷰 포인트
리뷰어가 집중해서 봐줬으면 하는 부분을 적어주세요.
- 여기에 적어주세요

---

## 📎 기타 참고 사항
리뷰에 도움이 될만한 추가 맥락, 스크린샷, 관련 문서 링크 등을 남겨주세요.
### 어드민 리스트 조회 API 호출
<img width="705" height="320" alt="image" src="https://github.com/user-attachments/assets/1b0bc279-6312-4bfc-bcf2-aa4b47404160" />
- id값도 같이 나오는 것을 확인할 수 있다
