### PR TITLE
[Hotfix] 게시글 상세 페이지 아티스트 프로필 이미지 추가 제공

### DIFF
--- a/src/main/java/com/fifo/compasstep/post/dto/response/PostDetailResponseDTO.java
+++ b/src/main/java/com/fifo/compasstep/post/dto/response/PostDetailResponseDTO.java
@@ -13,6 +13,7 @@ public class PostDetailResponseDTO {
     private String songTitle;
     private String artistName;
     private String s3FileKey;
+    private String artistProfileImage;
     private boolean analyzed;
     private List<CommentItem> comments;
 

--- a/src/main/java/com/fifo/compasstep/post/service/PostService.java
+++ b/src/main/java/com/fifo/compasstep/post/service/PostService.java
@@ -75,6 +75,8 @@ public class PostService {
                 ? post.getSong().getUser().getNickname()
                 : post.getSong().getUser().getName();
 
+        String artistProfileImage = post.getSong().getUser().getS3FileImage();
+
         var comments = guestCommentRepository.findByPost_IdOrderByCreatedAtAsc(postId).stream()
                 .map(gc -> PostDetailResponseDTO.CommentItem.builder()
                         .commentId(gc.getId())
@@ -89,6 +91,7 @@ public class PostService {
                 .songTitle(title)
                 .artistName(artistName)
                 .s3FileKey(s3Key)
+                .artistProfileImage(artistProfileImage)
                 .analyzed(post.isAnalyzed())
                 .comments(comments)
                 .build();


### PR DESCRIPTION
1. DTO에 artistProfileImage 추가
2. Service에서 DTO양식에 맞도록 artistProfileImage 주입

## 🔗 관련 이슈
해당 PR이 연결되는 이슈 번호를 명시하세요.  
예) Issue #11, Issue #42

---

## ✨ 변경 내용
이번 PR에서 어떤 작업을 했는지 요약해주세요.
- DTO에 artistProfileImage 추가
- Service에서 DTO양식에 맞도록 artistProfileImage 주입

---

## 🧪 테스트 방법
어떻게 동작을 검증했는지 작성해주세요.
- [ ] swagger를 통한 테스트

---

## 👀 리뷰 포인트
리뷰어가 집중해서 봐줬으면 하는 부분을 적어주세요.
- 여기에 적어주세요

---

## 📎 기타 참고 사항
리뷰에 도움이 될만한 추가 맥락, 스크린샷, 관련 문서 링크 등을 남겨주세요.
### 실제 api 호출 결과
<img width="531" height="449" alt="image" src="https://github.com/user-attachments/assets/19c3cb14-2b2f-4749-9bd8-20e47272be2f" />
